### PR TITLE
remote: Initial support to remove a remote

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -57,6 +57,7 @@ moss_sources = [
 	'source/moss/client/cli/remote_add.d',
 	'source/moss/client/cli/remote_list.d',
 	'source/moss/client/cli/remote_update.d',
+	'source/moss/client/cli/remote_remove.d',
 	'source/moss/client/cli/remote.d',
 	'source/moss/client/cli/remove.d',
 	'source/moss/client/cli/search.d',

--- a/source/moss/client/cli/index.d
+++ b/source/moss/client/cli/index.d
@@ -163,6 +163,9 @@ auto getName(scope MetaPayload payload) @trusted
 
         w.close();
 
+        info(format!"Successfully wrote index to %s, containing %s stones."(idxFile,
+                payloads.length));
+
         return 0;
     }
 }

--- a/source/moss/client/cli/package.d
+++ b/source/moss/client/cli/package.d
@@ -27,6 +27,7 @@ import moss.client.cli.remote;
 import moss.client.cli.remote_add;
 import moss.client.cli.remote_list;
 import moss.client.cli.remote_update;
+import moss.client.cli.remote_remove;
 import moss.client.cli.remove;
 import moss.client.cli.search;
 import moss.client;
@@ -76,6 +77,7 @@ package auto initialiseClient(scope ref BaseCommand pt) @trusted
         list.addCommand!ListInstalledCommand;
         auto remotes = p.addCommand!RemoteCommand;
         remotes.addCommand!RemoteAddCommand;
+        remotes.addCommand!RemoteRemoveCommand;
         remotes.addCommand!RemoteListCommand;
         remotes.addCommand!RemoteUpdateCommand;
         p.addCommand!InfoCommand;

--- a/source/moss/client/cli/remote_remove.d
+++ b/source/moss/client/cli/remote_remove.d
@@ -1,0 +1,78 @@
+/*
+ * SPDX-FileCopyrightText: Copyright © 2020-2022 Serpent OS Developers
+ *
+ * SPDX-License-Identifier: Zlib
+ */
+
+/**
+ * moss.client.cli.remote_remove
+ *
+ * Remove remotes from the system
+ *
+ * Authors: Copyright © 2020-2022 Serpent OS Developers
+ * License: Zlib
+ */
+
+module moss.client.cli.remote_remove;
+
+public import moss.core.cli;
+
+import moss.client.cli : initialiseClient;
+import moss.core.errors;
+import std.algorithm : filter;
+import std.array;
+import std.format;
+import std.stdio : writeln;
+import std.sumtype;
+import std.experimental.logger;
+import moss.client.ui;
+import std.stdint : uint64_t;
+
+/**
+ * Remove a remote from the system
+ */
+@CommandName("remove") @CommandAlias("rr") @CommandUsage("[name]") @CommandHelp(
+        "Remove an existing remote collection index from the system.") struct RemoteRemoveCommand
+{
+    BaseCommand pt;
+    alias pt this;
+
+    /**
+     * Dispatch the remove command
+     */
+    @CommandEntry() int run(ref string[] argv) @safe
+    {
+        if (argv.length != 1)
+        {
+            writeln("remove: Requires [name] as a parameter");
+            return 1;
+        }
+
+        auto cl = initialiseClient(pt);
+        scope (exit)
+        {
+            cl.close();
+        }
+        auto name = argv[0];
+
+        auto match = cl.remotes.active.filter!((r) => r.id == name);
+        if (match.empty)
+        {
+            error(format!"remote %s not found. Use 'remote list' to view remotes."(name));
+            return 1;
+        }
+
+        if (cl.remotes.active.length == 1)
+        {
+            error("Refusing to remove only existing remote.");
+            return 1;
+        }
+
+        /* FIXME: Show all .stones that would be orphaned due to coming from this remote */
+
+        return cl.remotes.remove(name).match!((Failure f) {
+            errorf("%s", f.message);
+            return 1;
+        }, (_) { infof("Removed remote %s", name); return 0; });
+    }
+}

--- a/source/moss/client/remotes.d
+++ b/source/moss/client/remotes.d
@@ -109,7 +109,7 @@ public final class RemoteManager
     uri: "%s"
     priority: %s
 `(saneID, description, origin, priority);
-        tracef("New config at: %s", confFile);
+        trace(format!"New config at: %s"(confFile));
         confFile.dirName.mkdirRecurse();
 
         write(confFile, data);
@@ -149,12 +149,12 @@ public final class RemoteManager
         {
             immutable indexFile = installation.joinPath(".moss", "remotes",
                     plugin.remoteConfig.id, plugin.remoteConfig.uri.baseName);
-            infof("Rebuilding indices on `%s`", plugin.remoteConfig.id);
+            info(format!"Rebuilding indices on `%s`"(plugin.remoteConfig.id));
 
             auto remotePath = installation.joinPath(".moss", "remotes", plugin.remoteConfig.id);
             remotePath.mkdirRecurse();
             plugin.loadFromIndex(indexFile).match!((Failure f) {
-                errorf("Failed to refresh plugin: %s", f.message);
+                error(format!"Failed to refresh plugin: %s"(f.message));
             }, (_) {});
         }
 

--- a/source/moss/client/remotes.d
+++ b/source/moss/client/remotes.d
@@ -121,6 +121,35 @@ public final class RemoteManager
     }
 
     /**
+     * Remove an existing remote
+     *
+     * Params:
+     *      identifier = Unique identifier for the remote
+     * Returns: A RemoteResult
+     */
+    RemoteResult remove(string identifier) @safe
+    {
+        import std.file : remove, rmdirRecurse;
+
+        /**
+         * Mutable only!
+         */
+        if (installation.mutability != Mutability.ReadWrite)
+        {
+            return cast(RemoteResult) fail("Cannot remove remote to non-mutable system");
+        }
+
+        immutable saneID = identifier.map!((m) => (m.isAlphaNum ? m : '_').toLower)
+            .to!string;
+        immutable confFile = installation.joinPath("etc", "moss", "repos.conf.d", saneID ~ ".conf");
+        auto remotePath = installation.joinPath(".moss", "remotes", saneID);
+        confFile.remove();
+        remotePath.rmdirRecurse();
+
+        return cast(RemoteResult) Success();
+    }
+
+    /**
      * Refresh all of the remotes
      *
      * Returns: RemoteResult


### PR DESCRIPTION
Currently this removes the remote from the system but leaves any orphaned stones behind.