### PR TITLE
cli/remote_add: Perform basic error checking that the URI is valid

### DIFF
--- a/source/moss/client/cli/remote.d
+++ b/source/moss/client/cli/remote.d
@@ -28,3 +28,5 @@ import moss.client.cli : initialiseClient;
     BaseCommand pt;
     alias pt this;
 }
+
+immutable auto SupportedProtocols = ["https://", "http://", "file://", "ftp://"];


### PR DESCRIPTION
When adding a remote do some basic error checking the URI is valid