### PR TITLE
cli/la: Support filtering by remote to match li

### DIFF
--- a/source/moss/client/cli/list_available.d
+++ b/source/moss/client/cli/list_available.d
@@ -45,6 +45,7 @@ import std.range : empty;
         }
         DisplayItem[] di = () @trusted {
             return cl.registry.list(ItemFlags.Available).filter!((i) {
+                /* no collection id specified, list all available packages */
                 if (collectionID is null)
                 {
                     return true;

--- a/source/moss/client/cli/list_installed.d
+++ b/source/moss/client/cli/list_installed.d
@@ -46,6 +46,7 @@ import std.range : empty;
         }
         DisplayItem[] di = () @trusted {
             return cl.registry.list(ItemFlags.Installed).filter!((i) {
+                /* no collection id specified, list all installed packages */
                 if (collectionID is null)
                 {
                     return true;

--- a/source/moss/client/cli/list_installed.d
+++ b/source/moss/client/cli/list_installed.d
@@ -17,17 +17,16 @@ module moss.client.cli.list_installed;
 
 public import moss.core.cli;
 
-import moss.client.remoteplugin;
 import moss.client.cli : initialiseClient;
-import moss.deps.registry;
+import moss.client.cli.list : DisplayItem, printItem;
 import moss.client.ui;
-import std.stdio : writefln;
+import moss.client.remoteplugin;
+import moss.deps.registry;
 import std.algorithm : map;
 import std.array : array;
-import std.algorithm : each, sort, SwapStrategy, maxElement, filter;
-import std.range : empty;
-import moss.client.cli.list : DisplayItem, printItem;
+import std.algorithm : each, filter, map ,maxElement, sort, SwapStrategy;
 import std.format;
+import std.range : empty;
 
 /**
  * List the installed packages


### PR DESCRIPTION
To match the list-installed functionality

Test plan:
```
$ moss remote list -D rootfs/
protosnek [active] priority = 0
    https://dev.serpentos.com/protosnek/x86_64/stone.index
local [active] priority = 5
    file:///var/cache/boulder/collections/local-x86_64/stone.index
$ moss la -D rootfs/ | wc -l
150
$ moss la -c local -D rootfs/ | wc -l
9
$ moss la -c protosnek -D rootfs/ | wc -l
141
```