### PR TITLE
Hook up support to allow user to describe remotes on system

### DIFF
--- a/source/moss/client/cli/remote_add.d
+++ b/source/moss/client/cli/remote_add.d
@@ -27,9 +27,7 @@ import std.format;
 import std.stdio : writeln;
 import std.sumtype;
 import std.experimental.logger;
-import moss.client.ui;
 import std.stdint : uint64_t;
-import std.stdio;
 
 /**
  * Add a remote to the system

--- a/source/moss/client/cli/remote_add.d
+++ b/source/moss/client/cli/remote_add.d
@@ -115,7 +115,7 @@ import std.stdio;
     }
 
     /* Optional user description for remote */
-    @Option("c", "description", "User description to help identify the remote")
+    @Option("c", "comment", "User comment to help identify the remote")
     string description = "User added repository";
     /* Higher priority wins */
     @Option("p", "priority", "Priority to enable this remote with")

--- a/source/moss/client/cli/remote_add.d
+++ b/source/moss/client/cli/remote_add.d
@@ -108,15 +108,16 @@ import std.stdio;
             }
         }
 
-        return cl.remotes.add(name, uri, priority).match!((Failure f) {
+        return cl.remotes.add(name, uri, description, priority).match!((Failure f) {
             errorf("%s", f.message);
             return 1;
         }, (_) { infof("Added remote %s", name); return 0; });
     }
 
-    /**
-     * Higher priority wins
-     */
+    /* Optional user description for remote */
+    @Option("c", "description", "User description to help identify the remote")
+    string description = "User added repository";
+    /* Higher priority wins */
     @Option("p", "priority", "Priority to enable this remote with")
     uint64_t priority = 0;
 }

--- a/source/moss/client/cli/remote_list.d
+++ b/source/moss/client/cli/remote_list.d
@@ -18,7 +18,9 @@ module moss.client.cli.remote_list;
 public import moss.core.cli;
 
 import moss.client.cli : initialiseClient;
-import std.stdio : writefln;
+import moss.client.ui;
+import std.stdio : writeln, writefln;
+import std.string : format;
 
 /**
  * List remotes on the system
@@ -41,7 +43,11 @@ import std.stdio : writefln;
 
         foreach (rm; cl.remotes.active)
         {
-            writefln("%s [active] priority = %s\n    %s", rm.id, rm.priority, rm.uri);
+            writeln(format!"%s %s %s %s %s %s %s"(Text(rm.id)
+                    .fg(Color.Magenta).attr(Attribute.Bold), Text("[active]")
+                    .fg(Color.Green), Text(rm.uri).fg(Color.White),
+                    Text("Priority:").fg(Color.Blue), rm.priority, Text("Description:")
+                    .fg(Color.Yellow), Text(rm.description).attr(Attribute.Italic)));
         }
         return 0;
     }

--- a/source/moss/client/cli/remote_list.d
+++ b/source/moss/client/cli/remote_list.d
@@ -41,13 +41,37 @@ import std.string : format;
             cl.close();
         }
 
+        /* Get the max length to calculate padding */
+        ulong idMaxLen = 0;
+        ulong uriMaxLen = 0;
         foreach (rm; cl.remotes.active)
         {
-            writeln(format!"%s %s %s %s %s %s %s"(Text(rm.id)
-                    .fg(Color.Magenta).attr(Attribute.Bold), Text("[active]")
-                    .fg(Color.Green), Text(rm.uri).fg(Color.White),
-                    Text("Priority:").fg(Color.Blue), rm.priority, Text("Description:")
-                    .fg(Color.Yellow), Text(rm.description).attr(Attribute.Italic)));
+            auto idLen = rm.id.length;
+            if (idLen > idMaxLen)
+            {
+                idMaxLen = idLen;
+            }
+            auto uriLen = rm.uri.length;
+            if (uriLen > uriMaxLen)
+            {
+                uriMaxLen = uriLen;
+            }
+        }
+
+        /* print it out */
+        foreach (rm; cl.remotes.active)
+        {
+            /* Calculate padding between elements for consistent output */
+            auto idPadding = (idMaxLen - rm.id.length) + 2;
+            auto uriPadding = (uriMaxLen - rm.uri.length) + 2;
+
+            /* id, idPadding, active, uri, uriPadding, priority, priorityNum, Description, descString */
+            writeln(format!"%s %*s %s %s %*s %s %s %s %s"(Text(rm.id)
+                    .fg(Color.Magenta).attr(Attribute.Bold), idPadding, " ",
+                    Text("[active]").fg(Color.Green), Text(rm.uri)
+                    .fg(Color.White), uriPadding, " ", Text("Priority:").fg(Color.Blue),
+                    rm.priority, Text("Description:").fg(Color.Yellow),
+                    Text(rm.description).attr(Attribute.Italic)));
         }
         return 0;
     }

--- a/source/moss/client/cli/remote_list.d
+++ b/source/moss/client/cli/remote_list.d
@@ -62,15 +62,15 @@ import std.string : format;
         foreach (rm; cl.remotes.active)
         {
             /* Calculate padding between elements for consistent output */
-            auto idPadding = (idMaxLen - rm.id.length) + 2;
-            auto uriPadding = (uriMaxLen - rm.uri.length) + 2;
+            auto idPadding = (idMaxLen - rm.id.length) + 1;
+            auto uriPadding = (uriMaxLen - rm.uri.length) + 1;
 
-            /* id, idPadding, active, uri, uriPadding, priority, priorityNum, Description, descString */
+            /* id, idPadding, active, uri, uriPadding, priority, priorityNum, comment, descString */
             writeln(format!"%s %*s %s %s %*s %s %s %s %s"(Text(rm.id)
                     .fg(Color.Magenta).attr(Attribute.Bold), idPadding, " ",
                     Text("[active]").fg(Color.Green), Text(rm.uri)
                     .fg(Color.White), uriPadding, " ", Text("Priority:").fg(Color.Blue),
-                    rm.priority, Text("Description:").fg(Color.Yellow),
+                    rm.priority, Text("Comment:").fg(Color.Yellow),
                     Text(rm.description).attr(Attribute.Italic)));
         }
         return 0;

--- a/source/moss/client/cli/remote_list.d
+++ b/source/moss/client/cli/remote_list.d
@@ -19,7 +19,7 @@ public import moss.core.cli;
 
 import moss.client.cli : initialiseClient;
 import moss.client.ui;
-import std.stdio : writeln, writefln;
+import std.stdio : writeln;
 import std.string : format;
 
 /**

--- a/source/moss/client/remotes.d
+++ b/source/moss/client/remotes.d
@@ -87,7 +87,7 @@ public final class RemoteManager
      *      origin = Where to download things from.
      * Returns: A RemoteResult
      */
-    RemoteResult add(string identifier, string origin, uint64_t priority = 0) @safe
+    RemoteResult add(string identifier, string origin, string description, uint64_t priority = 0) @safe
     {
         import std.file : write;
 
@@ -102,7 +102,6 @@ public final class RemoteManager
         immutable saneID = identifier.map!((m) => (m.isAlphaNum ? m : '_').toLower)
             .to!string;
         immutable confFile = installation.joinPath("etc", "moss", "repos.conf.d", saneID ~ ".conf");
-        immutable description = "User added repository";
         immutable data = format!`
 - %s:
     description: "%s"


### PR DESCRIPTION
This was already hooked up behind the scenes but was not configurable by the user, change that.

Descriptions are handy to help identify remotes, e.g. local repo, repo for unsupported software, etc.

test plan:
```
$ moss remote add local file:///var/cache/boulder/collections/local-x86_64/stone.index -c "Local boulder repo" -p 5 -D ~/sos/rootfs/
 INFO      Rebuilding indices on `protosnek`
 INFO      Rebuilding indices on `local`
 INFO      Added remote local
$ moss remote list -D ~/sos/rootfs/
protosnek   [active] https://dev.serpentos.com/protosnek/x86_64/stone.index           Priority: 0 Comment: User added repository
local       [active] file:///var/cache/boulder/collections/local-x86_64/stone.index   Priority: 5 Comment: Local boulder repo
```