### PR TITLE
Triggers cleanup

### DIFF
--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -17,8 +17,6 @@ const EXTENSION: &str = "yaml";
 
 pub trait Config: DeserializeOwned {
     fn domain() -> String;
-
-    fn merge(self, other: Self) -> Self;
 }
 
 #[derive(Debug, Clone)]
@@ -57,11 +55,7 @@ impl Manager {
         }
     }
 
-    pub async fn load<T: Config>(&self) -> Option<T> {
-        self.load_all().await.into_iter().reduce(T::merge)
-    }
-
-    pub async fn load_all<T: Config>(&self) -> Vec<T> {
+    pub async fn load<T: Config>(&self) -> Vec<T> {
         let domain = T::domain();
 
         let mut configs = vec![];

--- a/crates/fnmatch/src/lib.rs
+++ b/crates/fnmatch/src/lib.rs
@@ -284,7 +284,7 @@ impl Eq for Pattern {}
 
 impl PartialOrd for Pattern {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.pattern.partial_cmp(&other.pattern)
+        Some(self.cmp(other))
     }
 }
 

--- a/crates/moss/src/client/mod.rs
+++ b/crates/moss/src/client/mod.rs
@@ -25,6 +25,7 @@ use tui::{MultiProgress, ProgressBar, ProgressStyle, Stylize};
 use vfs::tree::{builder::TreeBuilder, BlitFile, Element};
 
 use self::install::install;
+use self::postblit::postblit;
 use self::prune::prune;
 use crate::{
     db, environment, package,
@@ -36,7 +37,7 @@ use crate::{
 
 pub mod cache;
 pub mod install;
-pub mod postblit;
+mod postblit;
 pub mod prune;
 
 /// A Client is a connection to the underlying package management systems
@@ -241,7 +242,7 @@ impl Client {
                 }
 
                 record_os_release(&self.installation.staging_dir(), Some(state.id)).await?;
-                postblit::handle_postblits(fstree, &self.installation).await?;
+                postblit(fstree, &self.installation).await?;
 
                 // Staging is only used with [`Scope::Stateful`]
                 self.promote_staging().await?;

--- a/crates/moss/src/client/postblit.rs
+++ b/crates/moss/src/client/postblit.rs
@@ -11,7 +11,6 @@
 use std::process;
 
 use container::Container;
-use itertools::Itertools;
 use serde::Deserialize;
 use thiserror::Error;
 use triggers::{
@@ -47,15 +46,12 @@ pub async fn postblit(
         .join("share")
         .join("moss")
         .join("triggers");
-    let triggers: Vec<Trigger> = config::Manager::custom(datadir)
+    let triggers = config::Manager::custom(datadir)
         .load::<TransactionTrigger>()
-        .await
-        .into_iter()
-        .map(|w| w.0)
-        .collect_vec();
+        .await;
 
     // Push all transaction paths into the postblit trigger collection
-    let mut manager = triggers::Collection::new(triggers.iter())?;
+    let mut manager = triggers::Collection::new(triggers.iter().map(|t| &t.0))?;
     manager.process_paths(fstree.iter().map(|m| m.to_string()));
     let computed_triggers = manager.bake()?;
 

--- a/crates/moss/src/client/postblit.rs
+++ b/crates/moss/src/client/postblit.rs
@@ -41,7 +41,7 @@ impl config::Config for TransactionTrigger {
 }
 
 /// Handle all postblit tasks
-pub(crate) async fn handle_postblits(
+pub async fn postblit(
     fstree: vfs::tree::Tree<PendingFile>,
     install: &Installation,
 ) -> Result<(), Error> {

--- a/crates/moss/src/client/postblit.rs
+++ b/crates/moss/src/client/postblit.rs
@@ -51,9 +51,9 @@ pub async fn postblit(
         .await;
 
     // Push all transaction paths into the postblit trigger collection
-    let mut manager = triggers::Collection::new(triggers.iter().map(|t| &t.0))?;
-    manager.process_paths(fstree.iter().map(|m| m.to_string()));
-    let computed_triggers = manager.bake()?;
+    let mut collection = triggers::Collection::new(triggers.iter().map(|t| &t.0))?;
+    collection.process_paths(fstree.iter().map(|m| m.to_string()));
+    let computed_triggers = collection.bake()?;
 
     // Execute in dependency order
     for trigger in computed_triggers.iter() {

--- a/crates/moss/src/client/postblit.rs
+++ b/crates/moss/src/client/postblit.rs
@@ -32,12 +32,6 @@ impl config::Config for TransactionTrigger {
     fn domain() -> String {
         "tx".into()
     }
-
-    /// Despite using the config system, we load *all* trigger files
-    /// in a linear vec and never merge them
-    fn merge(self, other: Self) -> Self {
-        unimplemented!()
-    }
 }
 
 /// Handle all postblit tasks
@@ -54,7 +48,7 @@ pub async fn postblit(
         .join("moss")
         .join("triggers");
     let triggers: Vec<Trigger> = config::Manager::custom(datadir)
-        .load_all::<TransactionTrigger>()
+        .load::<TransactionTrigger>()
         .await
         .into_iter()
         .map(|w| w.0)

--- a/crates/moss/src/repository/manager.rs
+++ b/crates/moss/src/repository/manager.rs
@@ -76,7 +76,12 @@ impl Manager {
             Source::System(config) =>
             // Load all configs, default if none exist
             {
-                config.load::<repository::Map>().await.unwrap_or_default()
+                config
+                    .load::<repository::Map>()
+                    .await
+                    .into_iter()
+                    .reduce(repository::Map::merge)
+                    .unwrap_or_default()
             }
             Source::Explicit { repos, .. } => repos.clone(),
         };

--- a/crates/moss/src/repository/mod.rs
+++ b/crates/moss/src/repository/mod.rs
@@ -125,6 +125,10 @@ impl Map {
     pub fn iter(&self) -> impl Iterator<Item = (&Id, &Repository)> {
         self.0.iter()
     }
+
+    pub fn merge(self, other: Self) -> Self {
+        Self(self.0.into_iter().chain(other.0).collect())
+    }
 }
 
 impl IntoIterator for Map {
@@ -139,10 +143,6 @@ impl IntoIterator for Map {
 impl Config for Map {
     fn domain() -> String {
         "repo".into()
-    }
-
-    fn merge(self, other: Self) -> Self {
-        Self(self.0.into_iter().chain(other.0).collect())
     }
 }
 


### PR DESCRIPTION
A few small  things I noticed when reviewing triggers.


`Config::merge` doesn't make sense at the API level as it causes `unimplemented`. Default API should just always return an array of configs and merging can be handled by the consumer.