### PR TITLE
List orphan removal from sync

### DIFF
--- a/crates/moss/src/cli/sync.rs
+++ b/crates/moss/src/cli/sync.rs
@@ -79,16 +79,29 @@ pub async fn handle(args: &ArgMatches, root: &Path) -> Result<(), Error> {
         .iter()
         .filter(|p| client.is_ephemeral() || !installed.iter().any(|i| i.id == p.id))
         .collect::<Vec<_>>();
+    let removed = installed
+        .iter()
+        .filter(|p| !finalized.iter().any(|f| f.meta.name == p.meta.name))
+        .cloned()
+        .collect::<Vec<_>>();
 
-    if synced.is_empty() {
+    if synced.is_empty() && removed.is_empty() {
         println!("No packages to sync");
         return Ok(());
     }
 
-    println!("The following packages will be sync'd: ");
-    println!();
-    print_to_columns(synced.as_slice());
-    println!();
+    if !synced.is_empty() {
+        println!("The following packages will be sync'd: ");
+        println!();
+        print_to_columns(synced.as_slice());
+        println!();
+    }
+    if !removed.is_empty() {
+        println!("The following orphaned packages will be removed: ");
+        println!();
+        print_to_columns(removed.as_slice());
+        println!();
+    }
 
     // Must we prompt?
     let result = if yes_all {

--- a/crates/moss/src/registry/transaction.rs
+++ b/crates/moss/src/registry/transaction.rs
@@ -69,7 +69,7 @@ impl<'a> Transaction<'a> {
     }
 
     /// Remove a set of packages and their reverse dependencies
-    pub async fn remove(&mut self, packages: Vec<package::Id>) -> Result<(), Error> {
+    pub async fn remove(&mut self, packages: Vec<package::Id>) {
         // Get transposed subgraph
         let transposed = self.packages.transpose();
         let subgraph = transposed.subgraph(&packages);
@@ -79,8 +79,6 @@ impl<'a> Transaction<'a> {
             // Remove that package
             self.packages.remove_node(package);
         });
-
-        Ok(())
     }
 
     /// Return the package IDs in the fully baked configuration


### PR DESCRIPTION
And allow sync to run if no upgrades exist, but removals do.

This doesn't change the behavior of sync, as it previously removed orphans. We just didn't present that information to the user nor allow it to run if only removals exists & not upgrades