### PR TITLE
Drop the bitflags dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1293,7 +1293,6 @@ dependencies = [
 name = "moss"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.4.2",
  "bytes",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ resolver = "2"
 edition = "2021"
 
 [workspace.dependencies]
-bitflags = "2.4.1"
 bytes = "1.5.0"
 chrono = "0.4.30"
 clap = { version = "4.4.11", features = ["derive", "string"] }

--- a/moss/Cargo.toml
+++ b/moss/Cargo.toml
@@ -10,7 +10,6 @@ stone = { path = "../crates/stone" }
 tui = { path = "../crates/tui" }
 vfs = { path = "../crates/vfs" }
 
-bitflags.workspace = true
 bytes.workspace = true
 chrono.workspace = true
 clap.workspace = true

--- a/moss/src/cli/info.rs
+++ b/moss/src/cli/info.rs
@@ -42,14 +42,17 @@ pub fn handle(args: &ArgMatches) -> Result<(), Error> {
 
     for pkg in pkgs {
         let lookup = Provider::from_name(&pkg).unwrap();
-        let resolved = client.registry.by_provider(&lookup, Flags::NONE).collect::<Vec<_>>();
+        let resolved = client
+            .registry
+            .by_provider(&lookup, Flags::default())
+            .collect::<Vec<_>>();
         if resolved.is_empty() {
             return Err(Error::NotFound(pkg));
         }
         for candidate in resolved {
             print_package(&candidate);
 
-            if candidate.flags.contains(Flags::INSTALLED) && show_files {
+            if candidate.flags.installed && show_files {
                 let vfs = client.vfs([&candidate.id])?;
                 print_files(vfs);
             }

--- a/moss/src/cli/list.rs
+++ b/moss/src/cli/list.rs
@@ -49,12 +49,12 @@ pub fn handle(args: &ArgMatches) -> Result<(), Error> {
     let root = args.get_one::<PathBuf>("root").unwrap().clone();
 
     let (filter_flags, sync) = match args.subcommand() {
-        Some(("available", _)) => (Flags::AVAILABLE, None),
+        Some(("available", _)) => (Flags::new().with_available(), None),
         Some(("installed", args)) => {
             let flags = if *args.get_one::<bool>("explicit").unwrap() {
-                Flags::INSTALLED | Flags::EXPLICIT
+                Flags::new().with_installed().with_explicit()
             } else {
-                Flags::INSTALLED
+                Flags::new().with_installed()
             };
             (flags, None)
         }
@@ -65,7 +65,7 @@ pub fn handle(args: &ArgMatches) -> Result<(), Error> {
                 Sync::All
             };
 
-            (Flags::INSTALLED, Some(sync))
+            (Flags::new().with_installed(), Some(sync))
         }
         _ => unreachable!(),
     };
@@ -75,7 +75,7 @@ pub fn handle(args: &ArgMatches) -> Result<(), Error> {
     let pkgs = client.registry.list(filter_flags).collect::<Vec<_>>();
 
     let sync_available = if sync.is_some() {
-        client.registry.list(Flags::AVAILABLE).collect::<Vec<_>>()
+        client.registry.list(Flags::new().with_available()).collect::<Vec<_>>()
     } else {
         vec![]
     };
@@ -113,8 +113,8 @@ pub fn handle(args: &ArgMatches) -> Result<(), Error> {
                     release: p.meta.source_release.to_string(),
                 },
                 summary: p.meta.summary,
-                explicit: if filter_flags == Flags::INSTALLED {
-                    p.flags.contains(Flags::EXPLICIT)
+                explicit: if filter_flags == Flags::new().with_installed() {
+                    p.flags.explicit
                 } else {
                     true
                 },

--- a/moss/src/cli/remove.rs
+++ b/moss/src/cli/remove.rs
@@ -42,7 +42,7 @@ pub fn handle(args: &ArgMatches, root: &Path) -> Result<(), Error> {
     // Grab a client for the target, enumerate packages
     let client = Client::new(environment::NAME, root)?;
 
-    let installed = client.registry.list_installed(Flags::NONE).collect::<Vec<_>>();
+    let installed = client.registry.list_installed(Flags::default()).collect::<Vec<_>>();
     let installed_ids = installed.iter().map(|p| p.id.clone()).collect::<HashSet<_>>();
 
     // Separate packages between installed / not installed (or invalid)

--- a/moss/src/client/install.rs
+++ b/moss/src/client/install.rs
@@ -30,7 +30,7 @@ pub fn install(client: &mut Client, pkgs: &[&str], yes: bool) -> Result<(), Erro
     let resolved = client.resolve_packages(tx.finalize())?;
 
     // Get installed packages to check against
-    let installed = client.registry.list_installed(Flags::NONE).collect::<Vec<_>>();
+    let installed = client.registry.list_installed(Flags::default()).collect::<Vec<_>>();
     let is_installed = |p: &Package| installed.iter().any(|i| i.meta.name == p.meta.name);
 
     // Get missing packages that are:
@@ -126,7 +126,10 @@ fn resolve_input(pkgs: &[&str], client: &Client) -> Result<Vec<package::Id>, Err
 /// Resolve a package name to the first package
 fn find_packages(id: &str, client: &Client) -> (String, Option<Package>) {
     let provider = Provider::from_name(id).unwrap();
-    let result = client.registry.by_provider(&provider, Flags::AVAILABLE).next();
+    let result = client
+        .registry
+        .by_provider(&provider, Flags::new().with_available())
+        .next();
 
     // First only, pre-sorted
     (id.into(), result)

--- a/moss/src/package/mod.rs
+++ b/moss/src/package/mod.rs
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use bitflags::bitflags;
 use derive_more::{AsRef, Display, From, Into};
 use itertools::Itertools;
 
@@ -51,20 +50,59 @@ impl Ord for Package {
     }
 }
 
-bitflags! {
-    /// Flags indicating the status of a [`Package`]
-    #[derive(Debug, Clone,Copy, PartialEq, Eq)]
-    pub struct Flags: u8 {
-        /// No filter flags
-        const NONE = 0;
-        /// Package is available for installation
-        const AVAILABLE = 1 << 1;
-        /// Package is already installed
-        const INSTALLED = 1 << 2;
-        /// Available as from-source build
-        const SOURCE = 1 << 3;
-        /// Package is explicitly installed (use with [`Flags::INSTALLED`])
-        const EXPLICIT = 1 << 4;
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Flags {
+    /// Package is available for installation.
+    pub available: bool,
+    /// Package is already installed.
+    pub installed: bool,
+    /// Available as from-source build.
+    pub source: bool,
+    /// Package is explicitly installed (use with [`Flags::installed`]).
+    pub explicit: bool,
+}
+
+impl Flags {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns a copy of [`Flags`] with available set to true.
+    pub fn with_available(&self) -> Self {
+        Self {
+            available: true,
+            ..*self
+        }
+    }
+
+    /// Returns a copy of [`Flags`] with installed set to true.
+    pub fn with_installed(&self) -> Self {
+        Self {
+            installed: true,
+            ..*self
+        }
+    }
+
+    /// Returns a copy of [`Flags`] with source set to true.
+    pub fn with_source(&self) -> Self {
+        Self { source: true, ..*self }
+    }
+
+    /// Returns a copy of [`Flags`] with explicit set to true.
+    pub fn with_explicit(&self) -> Self {
+        Self {
+            explicit: true,
+            ..*self
+        }
+    }
+
+    /// Returns whether this flag set contains another flag set.
+    pub fn contains(&self, other: Self) -> bool {
+        (self.bits() & other.bits()) == other.bits()
+    }
+
+    fn bits(&self) -> u32 {
+        (self.available as u32) | (self.installed as u32) << 1 | (self.source as u32) << 2 | (self.explicit as u32) << 3
     }
 }
 

--- a/moss/src/registry/mod.rs
+++ b/moss/src/registry/mod.rs
@@ -72,12 +72,12 @@ impl Registry {
 
     /// Return a sorted stream of installed [`Package`]
     pub fn list_installed(&self, flags: package::Flags) -> impl Iterator<Item = Package> + '_ {
-        self.list(flags | package::Flags::INSTALLED)
+        self.list(flags.with_installed())
     }
 
     /// Return a sorted stream of available [`Package`]
     pub fn list_available(&self, flags: package::Flags) -> impl Iterator<Item = Package> + '_ {
-        self.list(flags | package::Flags::AVAILABLE)
+        self.list(flags.with_available())
     }
 
     /// Return a new transaction for this registry
@@ -122,7 +122,7 @@ mod test {
                 hash: Default::default(),
                 download_size: Default::default(),
             },
-            flags: package::Flags::NONE,
+            flags: package::Flags::default(),
         };
 
         registry.add_plugin(Plugin::Test(plugin::Test::new(
@@ -137,7 +137,7 @@ mod test {
             vec![package("c", 50), package("d", 1)],
         )));
 
-        let query = registry.list(package::Flags::NONE);
+        let query = registry.list(package::Flags::default());
 
         // Packages are sorted by plugin priority, desc -> release number, desc
         for (idx, package) in query.enumerate() {
@@ -181,18 +181,18 @@ mod test {
         registry.add_plugin(Plugin::Test(plugin::test::Test::new(
             1,
             vec![
-                package("a", package::Flags::INSTALLED),
-                package("b", package::Flags::AVAILABLE),
-                package("c", package::Flags::SOURCE),
-                package("d", package::Flags::SOURCE | package::Flags::INSTALLED),
-                package("e", package::Flags::SOURCE | package::Flags::AVAILABLE),
+                package("a", package::Flags::new().with_installed()),
+                package("b", package::Flags::new().with_available()),
+                package("c", package::Flags::new().with_source()),
+                package("d", package::Flags::new().with_source().with_installed()),
+                package("e", package::Flags::new().with_source().with_available()),
             ],
         )));
 
-        let installed = registry.list_installed(package::Flags::NONE).collect();
-        let available = registry.list_available(package::Flags::NONE).collect();
-        let installed_source = registry.list_installed(package::Flags::SOURCE).collect();
-        let available_source = registry.list_available(package::Flags::SOURCE).collect();
+        let installed = registry.list_installed(package::Flags::default()).collect();
+        let available = registry.list_available(package::Flags::default()).collect();
+        let installed_source = registry.list_installed(package::Flags::new().with_source()).collect();
+        let available_source = registry.list_available(package::Flags::new().with_source()).collect();
 
         fn matches(actual: Vec<Package>, expected: &[&'static str]) -> bool {
             let actual = actual

--- a/moss/src/registry/plugin/active.rs
+++ b/moss/src/registry/plugin/active.rs
@@ -41,7 +41,7 @@ impl Active {
 
     /// Query, restricted to state
     fn query(&self, flags: package::Flags, filter: Option<db::meta::Filter>) -> Vec<Package> {
-        if flags.contains(package::Flags::INSTALLED) || flags == package::Flags::NONE {
+        if flags.installed || flags == package::Flags::default() {
             // TODO: Error handling
             let packages = match self.db.query(filter) {
                 Ok(packages) => packages,
@@ -55,13 +55,7 @@ impl Active {
                 .into_iter()
                 .filter_map(|(id, meta)| self.installed_package(id, meta))
                 // Filter for explicit only packages, if applicable
-                .filter(|package| {
-                    if flags.contains(package::Flags::EXPLICIT) {
-                        package.flags.contains(package::Flags::EXPLICIT)
-                    } else {
-                        true
-                    }
-                })
+                .filter(|package| if flags.explicit { package.flags.explicit } else { true })
                 .collect()
         } else {
             vec![]
@@ -97,9 +91,9 @@ impl Active {
                     id,
                     meta,
                     flags: if selection.explicit {
-                        package::Flags::INSTALLED | package::Flags::EXPLICIT
+                        package::Flags::new().with_installed().with_explicit()
                     } else {
-                        package::Flags::INSTALLED
+                        package::Flags::new().with_installed()
                     },
                 }),
             None => None,

--- a/moss/src/registry/plugin/cobble.rs
+++ b/moss/src/registry/plugin/cobble.rs
@@ -54,7 +54,7 @@ impl Cobble {
     }
 
     fn query(&self, flags: package::Flags, filter: impl Fn(&Meta) -> bool) -> Vec<Package> {
-        if flags.contains(package::Flags::AVAILABLE) {
+        if flags.available {
             self.packages
                 .iter()
                 .filter(|(_, state)| filter(&state.meta))
@@ -94,7 +94,7 @@ impl State {
             id,
             meta: self.meta.clone(),
             // TODO: Is this correct flag?
-            flags: package::Flags::AVAILABLE,
+            flags: package::Flags::new().with_available(),
         }
     }
 }

--- a/moss/src/registry/plugin/repository.rs
+++ b/moss/src/registry/plugin/repository.rs
@@ -39,7 +39,7 @@ impl Repository {
                         .map(|url| url.to_string()),
                     ..meta
                 },
-                flags: package::Flags::AVAILABLE,
+                flags: package::Flags::new().with_available(),
             }),
             Err(db::meta::Error::RowNotFound) => None,
             Err(error) => {
@@ -50,7 +50,7 @@ impl Repository {
     }
 
     fn query(&self, flags: package::Flags, filter: Option<db::meta::Filter>) -> Vec<Package> {
-        if flags.contains(package::Flags::AVAILABLE) || flags == package::Flags::NONE {
+        if flags.available || flags == package::Flags::default() {
             // TODO: Error handling
             let packages = match self.active.db.query(filter) {
                 Ok(packages) => packages,
@@ -65,7 +65,7 @@ impl Repository {
                 .map(|(id, meta)| Package {
                     id,
                     meta,
-                    flags: package::Flags::AVAILABLE,
+                    flags: package::Flags::new().with_available(),
                 })
                 .collect()
         } else {

--- a/moss/src/registry/transaction.rs
+++ b/moss/src/registry/transaction.rs
@@ -137,19 +137,19 @@ impl<'a> Transaction<'a> {
         match filter {
             ProviderFilter::All(provider) => self
                 .registry
-                .by_provider(&provider, package::Flags::AVAILABLE)
+                .by_provider(&provider, package::Flags::new().with_available())
                 .next()
                 .map(|p| p.id)
                 .ok_or(Error::NoCandidate(provider.to_string())),
             ProviderFilter::InstalledOnly(provider) => self
                 .registry
-                .by_provider(&provider, package::Flags::INSTALLED)
+                .by_provider(&provider, package::Flags::new().with_installed())
                 .next()
                 .map(|p| p.id)
                 .ok_or(Error::NoCandidate(provider.to_string())),
             ProviderFilter::Selections(provider) => self
                 .registry
-                .by_provider(&provider, package::Flags::NONE)
+                .by_provider(&provider, package::Flags::default())
                 .find_map(|p| {
                     if self.packages.node_exists(&p.id) {
                         Some(p.id)


### PR DESCRIPTION
This PR replaces the bitflags functionality with an in-house implementation.

I think we all agree on reducing the number of dependencies where it makes sense, and I also think bitflags is one dependency worth removing. It is based on a `macro_rule` which is able to escape the original Rust syntax (think of that `: u8` syntax to specify that flags are bytes. That's a C++ notation!), making code a little confusing. `macro_rules` have too much freedom of toying with the code, IMO.

The new `Flags` struct is a type-safe and value-safe collection of flags. It is not possible to build an invalid collection of Flags. The idea is based on `std::fs::OpenOptions`.

Did you note that `bits()` private method? That's a micro-optimization. While I could implement the `contains()` method using pure boolean logic, with Compiler Explorer I noticed that that would introduce conditional jumps in the assembly. For the sake of the CPU pipeline, I chose to convert the single flags back into an integer for the comparison, thus avoiding jumps altogether.