### PR TITLE
crates/tui: Simple refactor

### DIFF
--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -2,108 +2,38 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use std::io::{Read, Write};
-
-pub use self::reexport::*;
 pub use self::styled::Styled;
+pub use dialoguer;
+pub use indicatif::*;
 
 pub mod pretty;
 mod styled;
 
-const DEFAULT_TERM_SIZE: (u16, u16) = (80, 24);
-
-/// Simple terminal constraints wrapping
+/// The size of a terminal emulator window.
 pub struct TermSize {
+    /// Width (or number of columns) of the terminal, in characters.
     pub width: usize,
+    /// Height (or number of rows) of the terminal, in characters.
     pub height: usize,
 }
 
-/// Generate a sane-fallback TermSize
-pub fn term_size() -> TermSize {
-    let size = crossterm::terminal::size().unwrap_or(DEFAULT_TERM_SIZE);
-    let mapped = if size.0 < 1 || size.1 < 1 {
-        DEFAULT_TERM_SIZE
-    } else {
-        size
-    };
-    TermSize {
-        width: mapped.0 as usize,
-        height: mapped.1 as usize,
+impl Default for TermSize {
+    fn default() -> Self {
+        Self { width: 80, height: 24 }
     }
 }
 
-/// Wraps a [`Write`] and updates the provided [`ProgressBar`] with progress
-/// of total bytes written
-pub struct ProgressWriter<W> {
-    pub writer: W,
-    pub total: u64,
-    pub written: u64,
-    pub progress: ProgressBar,
-}
-
-impl<W> ProgressWriter<W> {
-    pub fn new(writer: W, total: u64, progress: ProgressBar) -> Self {
-        Self {
-            writer,
-            total,
-            written: 0,
-            progress,
+impl TermSize {
+    /// Returns a valid terminal size. If the system couldn't be queried,
+    /// it returns the default value.
+    pub fn get() -> Self {
+        let size = crossterm::terminal::size().unwrap_or_default();
+        if size.0 < 1 || size.1 < 1 {
+            return TermSize::default();
+        }
+        TermSize {
+            width: size.0 as usize,
+            height: size.1 as usize,
         }
     }
-}
-
-impl<W: Write> Write for ProgressWriter<W> {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        let bytes = self.writer.write(buf)?;
-
-        self.written += bytes as u64;
-        self.progress.set_position(
-            (self.written as f64 / self.total as f64 * self.progress.length().unwrap_or_default() as f64) as u64,
-        );
-
-        Ok(bytes)
-    }
-
-    fn flush(&mut self) -> std::io::Result<()> {
-        self.writer.flush()
-    }
-}
-
-/// Wraps a [`Read`] and updates the provided [`ProgressBar`] with progress
-/// of total bytes read
-pub struct ProgressReader<R> {
-    pub reader: R,
-    pub total: u64,
-    pub read: u64,
-    pub progress: ProgressBar,
-}
-
-impl<R> ProgressReader<R> {
-    pub fn new(reader: R, total: u64, progress: ProgressBar) -> Self {
-        Self {
-            reader,
-            total,
-            read: 0,
-            progress,
-        }
-    }
-}
-
-impl<R: Read> Read for ProgressReader<R> {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        let read = self.reader.read(buf)?;
-
-        self.read += read as u64;
-        self.progress.set_position(
-            (self.read as f64 / self.total as f64 * self.progress.length().unwrap_or_default() as f64) as u64,
-        );
-
-        Ok(read)
-    }
-}
-
-/// Provide a standard approach to ratatui based TUI in moss
-mod reexport {
-    pub use dialoguer;
-    pub use indicatif::*;
 }

--- a/crates/tui/src/pretty.rs
+++ b/crates/tui/src/pretty.rs
@@ -9,7 +9,7 @@ use std::{
     io::{stdout, Write},
 };
 
-use crate::term_size;
+use crate::TermSize;
 
 /// Simplistic handling of renderable display columns
 /// allowing implementations to handle first, n and last specific alignment
@@ -33,19 +33,19 @@ pub trait ColumnDisplay: Sized {
 /// These will be printed in individual columns assuming that the input order is
 /// alphabetically sorted, to give each column an ascending alpha sort.
 pub fn print_to_columns<T: ColumnDisplay>(items: &[T]) {
-    let terminal_width = term_size().width;
+    let terminal_width = TermSize::get().width;
 
     // Figure render constraints
     let largest_element = items.iter().max_by_key(|p| p.get_display_width() + 3).unwrap();
     let largest_width = largest_element.get_display_width() + 6;
     let num_columns = max(1, terminal_width / largest_width);
-    let height = ((items.len() as f32) / (num_columns as f32)).ceil() as usize;
+    let num_rows = ((items.len() as f32) / (num_columns as f32)).ceil() as usize;
 
     let mut stdout = stdout().lock();
 
-    for y in 0..height {
+    for y in 0..num_rows {
         for x in 0..num_columns {
-            let idx = y + (x * height);
+            let idx = y + (x * num_rows);
             let state = items.get(idx);
             if let Some(state) = state {
                 let column = if x == 0 {


### PR DESCRIPTION
This is mostly code style you may not agree with, but I think the replacement of the reader and writer wrappers is a win.

- `TermSize` now implements the Default trait, and the previous `get_size()` function is now `TermSize`'s constructor.
- `ProgressReader` and `ProgressWriter` are replaced by indicatif's `wrap_read()` and `wrap_write()`:
  - Shorter code
  - Prevents a previously possible division by zero
  - Those wrapper expose more methods than `read()` and `write()` for convenience