### PR TITLE
Feature/state management

### DIFF
--- a/moss/src/cli/remove.rs
+++ b/moss/src/cli/remove.rs
@@ -128,7 +128,7 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
     };
 
     // Apply state
-    client.apply_state(&new_state_pkgs, "Remove")?;
+    client.new_state(&new_state_pkgs, "Remove")?;
 
     Ok(())
 }

--- a/moss/src/cli/state.rs
+++ b/moss/src/cli/state.rs
@@ -15,6 +15,7 @@ pub fn command() -> Command {
         .about("Manage state")
         .long_about("Manage state ...")
         .subcommand_required(true)
+        .subcommand(Command::new("active").about("List the active state"))
         .subcommand(Command::new("list").about("List all states"))
         .subcommand(
             Command::new("prune").about("Prune old states").arg(
@@ -35,11 +36,25 @@ pub fn command() -> Command {
 
 pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error> {
     match args.subcommand() {
+        Some(("active", _)) => active(installation),
         Some(("list", _)) => list(installation),
         Some(("prune", args)) => prune(args, installation),
         Some(("activate", args)) => activate(args, installation),
         _ => unreachable!(),
     }
+}
+
+/// List the active state
+pub fn active(installation: Installation) -> Result<(), Error> {
+    if let Some(id) = installation.active_state {
+        let client = Client::new(environment::NAME, installation)?;
+
+        let state = client.state_db.get(&id)?;
+
+        print_state(state);
+    }
+
+    Ok(())
 }
 
 /// List all known states, newest first

--- a/moss/src/cli/sync.rs
+++ b/moss/src/cli/sync.rs
@@ -153,7 +153,7 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
     };
 
     // Perfect, apply state.
-    client.apply_state(&new_selections, "Sync")?;
+    client.new_state(&new_selections, "Sync")?;
 
     Ok(())
 }

--- a/moss/src/client/install.rs
+++ b/moss/src/client/install.rs
@@ -99,7 +99,7 @@ pub fn install(client: &mut Client, pkgs: &[&str], yes: bool) -> Result<(), Erro
     };
 
     // Perfect, apply state.
-    client.apply_state(&new_state_pkgs, "Install")?;
+    client.new_state(&new_state_pkgs, "Install")?;
 
     Ok(())
 }

--- a/moss/src/client/mod.rs
+++ b/moss/src/client/mod.rs
@@ -156,7 +156,7 @@ impl Client {
     }
 
     /// Prune states with the provided [`prune::Strategy`]
-    pub fn prune(&self, strategy: prune::Strategy) -> Result<(), Error> {
+    pub fn prune(&self, strategy: prune::Strategy, yes: bool) -> Result<(), Error> {
         if self.scope.is_ephemeral() {
             return Err(Error::EphemeralProhibitedOperation);
         }
@@ -167,6 +167,7 @@ impl Client {
             &self.install_db,
             &self.layout_db,
             &self.installation,
+            yes,
         )?;
         Ok(())
     }

--- a/moss/src/client/mod.rs
+++ b/moss/src/client/mod.rs
@@ -242,7 +242,7 @@ impl Client {
     pub fn new_state(&self, selections: &[Selection], summary: impl ToString) -> Result<Option<State>, Error> {
         let old_state = self.installation.active_state;
 
-        let fstree = self.blit_root(selections.iter().map(|s| &s.package), old_state.map(state::Id::next))?;
+        let fstree = self.blit_root(selections.iter().map(|s| &s.package))?;
 
         match &self.scope {
             Scope::Stateful => {
@@ -519,7 +519,6 @@ impl Client {
     fn blit_root<'a>(
         &self,
         packages: impl IntoIterator<Item = &'a package::Id>,
-        state_id: Option<state::Id>,
     ) -> Result<vfs::tree::Tree<PendingFile>, Error> {
         let progress = ProgressBar::new(1).with_style(
             ProgressStyle::with_template("\n|{bar:20.red/blue}| {pos}/{len} {msg}")
@@ -688,7 +687,14 @@ BUG_REPORT_URL="https://github.com/serpent-os""#,
         tx = state_id.unwrap_or_default()
     );
 
-    fs::write(root.join("usr").join("lib").join("os-release"), os_release)?;
+    // It's possible this doesn't exist if
+    // we remove all packages (=
+    let dir = root.join("usr").join("lib");
+    if !dir.exists() {
+        fs::create_dir(&dir)?;
+    }
+
+    fs::write(dir.join("os-release"), os_release)?;
 
     Ok(())
 }

--- a/moss/src/client/prune.rs
+++ b/moss/src/client/prune.rs
@@ -169,6 +169,15 @@ pub fn prune(
         |hash| Some(cache::asset_path(installation, &hash)),
     )?;
 
+    // Remove each state's archive folder
+    for state in removals {
+        let archive_path = installation.root_path(state.id.to_string());
+
+        if archive_path.exists() {
+            fs::remove_dir_all(&archive_path)?;
+        }
+    }
+
     Ok(())
 }
 

--- a/moss/src/state.rs
+++ b/moss/src/state.rs
@@ -11,7 +11,7 @@ use tui::{pretty, Styled};
 use crate::package;
 
 /// Unique identifier for [`State`]
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, From, Into, Display)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, From, Into, Display)]
 pub struct Id(i64);
 
 impl Id {


### PR DESCRIPTION
Adds `moss state remove / active / activate` and fixes `prune` to only consider before the current active state