### PR TITLE
Dont use Path API

### DIFF
--- a/crates/vfs/src/lib.rs
+++ b/crates/vfs/src/lib.rs
@@ -6,4 +6,5 @@
 pub use self::tree::Tree;
 
 pub mod cache;
+pub mod path;
 pub mod tree;

--- a/crates/vfs/src/path.rs
+++ b/crates/vfs/src/path.rs
@@ -1,0 +1,32 @@
+pub fn join(a: &str, b: &str) -> String {
+    if b.starts_with('/') {
+        b.to_string()
+    } else if a.ends_with('/') {
+        format!("{a}{b}")
+    } else {
+        format!("{a}/{b}")
+    }
+}
+
+pub fn file_name(path: &str) -> Option<&str> {
+    path.trim_end_matches('/').rsplit('/').next()
+}
+
+pub fn parent(path: &str) -> Option<&str> {
+    path.trim_end_matches('/').rsplit_once('/').map(|(parent, _)| {
+        // We had to have split on a direct descendent of `/`
+        if parent.is_empty() {
+            "/"
+        } else {
+            parent
+        }
+    })
+}
+
+pub fn components(path: &str) -> impl Iterator<Item = &str> {
+    path.starts_with('/')
+        .then_some("/")
+        .into_iter()
+        .chain(path.split('/'))
+        .filter(|s| !s.is_empty())
+}

--- a/moss/src/cli/info.rs
+++ b/moss/src/cli/info.rs
@@ -127,7 +127,7 @@ fn print_files(vfs: vfs::Tree<client::PendingFile>) {
     print_titled("Files");
     println!();
     for (path, meta) in files {
-        println!("  {}{}", path.display(), meta.unwrap_or_default().dim());
+        println!("  {path}{}", meta.unwrap_or_default().dim());
     }
 }
 

--- a/moss/src/client/mod.rs
+++ b/moss/src/client/mod.rs
@@ -735,7 +735,7 @@ impl BlitFile for PendingFile {
     }
 
     /// Resolve the target path, including the missing `/usr` prefix
-    fn path(&self) -> PathBuf {
+    fn path(&self) -> String {
         let result = match &self.layout.entry {
             layout::Entry::Regular(_, target) => target.clone(),
             layout::Entry::Symlink(_, target) => target.clone(),
@@ -745,28 +745,28 @@ impl BlitFile for PendingFile {
             layout::Entry::Fifo(target) => target.clone(),
             layout::Entry::Socket(target) => target.clone(),
         };
-        PathBuf::from("/usr").join(result)
+
+        vfs::path::join("/usr", &result)
     }
 
     /// Clone the node to a reparented path, for symlink resolution
-    fn cloned_to(&self, path: PathBuf) -> Self {
+    fn cloned_to(&self, path: String) -> Self {
         let mut new = self.clone();
-        let strpath = path.to_string_lossy().to_string();
         new.layout.entry = match &self.layout.entry {
-            layout::Entry::Regular(source, _) => layout::Entry::Regular(*source, strpath),
-            layout::Entry::Symlink(source, _) => layout::Entry::Symlink(source.clone(), strpath),
-            layout::Entry::Directory(_) => layout::Entry::Directory(strpath),
-            layout::Entry::CharacterDevice(_) => layout::Entry::CharacterDevice(strpath),
-            layout::Entry::BlockDevice(_) => layout::Entry::BlockDevice(strpath),
-            layout::Entry::Fifo(_) => layout::Entry::Fifo(strpath),
-            layout::Entry::Socket(_) => layout::Entry::Socket(strpath),
+            layout::Entry::Regular(source, _) => layout::Entry::Regular(*source, path),
+            layout::Entry::Symlink(source, _) => layout::Entry::Symlink(source.clone(), path),
+            layout::Entry::Directory(_) => layout::Entry::Directory(path),
+            layout::Entry::CharacterDevice(_) => layout::Entry::CharacterDevice(path),
+            layout::Entry::BlockDevice(_) => layout::Entry::BlockDevice(path),
+            layout::Entry::Fifo(_) => layout::Entry::Fifo(path),
+            layout::Entry::Socket(_) => layout::Entry::Socket(path),
         };
         new
     }
 }
 
-impl From<PathBuf> for PendingFile {
-    fn from(value: PathBuf) -> Self {
+impl From<String> for PendingFile {
+    fn from(value: String) -> Self {
         PendingFile {
             id: Default::default(),
             layout: layout::Layout {
@@ -774,7 +774,7 @@ impl From<PathBuf> for PendingFile {
                 gid: 0,
                 mode: 0o755,
                 tag: 0,
-                entry: layout::Entry::Directory(value.to_string_lossy().to_string()),
+                entry: layout::Entry::Directory(value),
             },
         }
     }
@@ -782,7 +782,7 @@ impl From<PathBuf> for PendingFile {
 
 impl ToString for PendingFile {
     fn to_string(&self) -> String {
-        self.path().to_string_lossy().to_string()
+        self.path()
     }
 }
 


### PR DESCRIPTION
We process a LOT of paths and the Path API is very costly. Let's do some slightly less robust logic on strings directly.

Is an 8% speedup from my test of blitting a root w/ `gdm` added.