### PR TITLE
boulder/data/macros: Ensure gcc's lto is parallelized

### DIFF
--- a/boulder/data/macros/arch/base.yml
+++ b/boulder/data/macros/arch/base.yml
@@ -368,12 +368,15 @@ flags               :
 
     # Enable LTO optimisations (OFF)
     - lto-full:
-        c         : "-flto"
-        cxx       : "-flto"
-        ld        : "-flto"
+        gnu:
+            c         : "-flto=%(jobs)"
+            cxx       : "-flto=%(jobs)"
+            ld        : "-flto=%(jobs)"
         llvm:
+            c         : "-flto"
+            cxx       : "-flto"
             d         : "-flto=full"
-
+            ld        : "-flto"
 
     # Enable Thin-LTO optimisations (OFF)
     - lto-thin:


### PR DESCRIPTION
Use number of jobs specified.