### PR TITLE
boulder/cli/build: Form full absolute path for CLI arguments

### DIFF
--- a/boulder/src/cli/build.rs
+++ b/boulder/src/cli/build.rs
@@ -58,18 +58,8 @@ pub fn handle(command: Command, env: Env) -> Result<(), Error> {
     let mut timing = Timing::default();
     let timer = timing.begin(timing::Kind::Initialize);
 
-    // Resolve dir to dir + stone.yml
-    let recipe_path = if recipe_path.is_dir() {
-        recipe_path.join("stone.yml")
-    } else {
-        recipe_path
-    };
-
     if !output.exists() {
         return Err(Error::MissingOutput(output));
-    }
-    if !recipe_path.exists() {
-        return Err(Error::MissingRecipe(recipe_path));
     }
 
     let builder = Builder::new(&recipe_path, env, profile, ccache)?;
@@ -111,8 +101,6 @@ pub fn handle(command: Command, env: Env) -> Result<(), Error> {
 pub enum Error {
     #[error("output directory does not exist: {0:?}")]
     MissingOutput(PathBuf),
-    #[error("recipe file does not exist: {0:?}")]
-    MissingRecipe(PathBuf),
     #[error("build recipe")]
     Build(#[from] build::Error),
     #[error("package artifacts")]

--- a/boulder/src/cli/chroot.rs
+++ b/boulder/src/cli/chroot.rs
@@ -21,17 +21,6 @@ pub struct Command {
 pub fn handle(command: Command, env: Env) -> Result<(), Error> {
     let Command { recipe: recipe_path } = command;
 
-    // Resolve dir to dir + stone.yml
-    let recipe_path = if recipe_path.is_dir() {
-        recipe_path.join("stone.yml")
-    } else {
-        recipe_path
-    };
-
-    if !recipe_path.exists() {
-        return Err(Error::MissingRecipe(recipe_path));
-    }
-
     let recipe = Recipe::load(recipe_path)?;
     let macros = Macros::load(&env)?;
     let paths = Paths::new(&recipe, env.cache_dir, "/mason")?;
@@ -86,8 +75,6 @@ pub fn handle(command: Command, env: Env) -> Result<(), Error> {
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("recipe file does not exist: {0:?}")]
-    MissingRecipe(PathBuf),
     #[error("build root doesn't exist, make sure to run build first")]
     MissingRootFs,
     #[error("container")]

--- a/boulder/src/recipe.rs
+++ b/boulder/src/recipe.rs
@@ -86,17 +86,17 @@ impl Recipe {
 }
 
 pub fn resolve_path(path: impl AsRef<Path>) -> Result<PathBuf, Error> {
-    // Ensure it's absolute
-    let path = fs::canonicalize(&path).map_err(|_| Error::MissingRecipe(path.as_ref().to_path_buf()))?;
+    let path = path.as_ref();
 
     // Resolve dir to dir + stone.yml
-    let path = if path.is_dir() { path.join("stone.yml") } else { path };
-
-    if path.exists() {
-        Ok(path)
+    let path = if path.is_dir() {
+        path.join("stone.yml")
     } else {
-        Err(Error::MissingRecipe(path))
-    }
+        path.to_path_buf()
+    };
+
+    // Ensure it's absolute & exists
+    fs::canonicalize(&path).map_err(|_| Error::MissingRecipe(path))
 }
 
 #[derive(Debug, Error)]

--- a/boulder/src/recipe.rs
+++ b/boulder/src/recipe.rs
@@ -19,7 +19,7 @@ pub struct Recipe {
 
 impl Recipe {
     pub fn load(path: impl Into<PathBuf>) -> Result<Self, Error> {
-        let path = path.into();
+        let path = fs::canonicalize(path.into())?;
         let source = fs::read_to_string(&path)?;
         let parsed = stone_recipe::from_str(&source)?;
 


### PR DESCRIPTION
Due to our magical namespace swapping we seem to "forget" where we are, so store the full path to the CLI argument when building with relative paths such as `boulder build stone.yml`