### PR TITLE
moss: Allow to search for packages with one keyword

### DIFF
--- a/moss/src/cli/mod.rs
+++ b/moss/src/cli/mod.rs
@@ -16,6 +16,7 @@ mod install;
 mod list;
 mod remove;
 mod repo;
+mod search;
 mod state;
 mod sync;
 mod version;
@@ -65,6 +66,7 @@ fn command() -> Command {
         .subcommand(list::command())
         .subcommand(remove::command())
         .subcommand(repo::command())
+        .subcommand(search::command())
         .subcommand(state::command())
         .subcommand(sync::command())
         .subcommand(version::command())
@@ -100,6 +102,7 @@ pub fn process() -> Result<(), Error> {
         Some(("list", args)) => list::handle(args, installation).map_err(Error::List),
         Some(("remove", args)) => remove::handle(args, installation).map_err(Error::Remove),
         Some(("repo", args)) => repo::handle(args, installation).map_err(Error::Repo),
+        Some(("search", args)) => search::handle(args, installation).map_err(Error::Search),
         Some(("state", args)) => state::handle(args, installation).map_err(Error::State),
         Some(("sync", args)) => sync::handle(args, installation).map_err(Error::Sync),
         Some(("version", _)) => {
@@ -170,6 +173,9 @@ pub enum Error {
 
     #[error("repo")]
     Repo(#[from] repo::Error),
+
+    #[error("search")]
+    Search(#[from] search::Error),
 
     #[error("state")]
     State(#[from] state::Error),

--- a/moss/src/cli/remove.rs
+++ b/moss/src/cli/remove.rs
@@ -17,7 +17,7 @@ use moss::{
 use thiserror::Error;
 use tui::{
     dialoguer::{theme::ColorfulTheme, Confirm},
-    pretty::print_to_columns,
+    pretty::autoprint_columns,
     Styled,
 };
 
@@ -77,7 +77,7 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
 
     println!("The following package(s) will be removed:");
     println!();
-    print_to_columns(&removed);
+    autoprint_columns(&removed);
     println!();
 
     let result = if yes {

--- a/moss/src/cli/search.rs
+++ b/moss/src/cli/search.rs
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: Copyright © 2020-2024 Serpent OS Developers
+//
+// SPDX-License-Identifier: MPL-2.0
+
+use clap::builder::NonEmptyStringValueParser;
+use clap::{Arg, ArgMatches, Command};
+
+use moss::client;
+use moss::package::{self, Name};
+use moss::{environment, Client, Installation};
+use tui::pretty::{print_columns, ColumnDisplay};
+use tui::Styled;
+
+const ARG_KEYWORD: &str = "KEYWORD";
+const FLAG_INSTALLED: &str = "installed";
+
+/// Returns the Clap struct for this command.
+pub fn command() -> Command {
+    Command::new("search")
+        .visible_alias("sr")
+        .about("Search packages")
+        .long_about("Search packages by looking into package names and summaries.")
+        .arg(
+            Arg::new(ARG_KEYWORD)
+                .required(true)
+                .num_args(1)
+                .value_parser(NonEmptyStringValueParser::new()),
+        )
+        .arg(
+            Arg::new(FLAG_INSTALLED)
+                .short('i')
+                .long("installed")
+                .num_args(0)
+                .help("Search among installed packages only"),
+        )
+}
+
+pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error> {
+    let keyword = args.get_one::<String>(ARG_KEYWORD).unwrap();
+    let only_installed = args.get_flag(FLAG_INSTALLED);
+
+    let client = Client::new(environment::NAME, installation)?;
+    let flags = if only_installed {
+        package::Flags::new().with_installed()
+    } else {
+        package::Flags::new().with_available()
+    };
+
+    let output: Vec<Output> = client
+        .registry
+        .by_keyword(keyword, flags)
+        .map(|pkg| Output {
+            name: pkg.meta.name,
+            summary: pkg.meta.summary,
+        })
+        .collect();
+    print_columns(&output, 1);
+    Ok(())
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("client")]
+    Client(#[from] client::Error),
+}
+
+const COLUMN_SPACING: usize = 4;
+
+struct Output {
+    name: Name,
+    summary: String,
+}
+
+impl ColumnDisplay for Output {
+    fn get_display_width(&self) -> usize {
+        // TODO: calculate the number of graphemes, not bytes.
+        // Now we are assuming name and summary are ASCII.
+        self.name.to_string().len() + self.summary.len() + COLUMN_SPACING
+    }
+
+    fn display_column(&self, writer: &mut impl std::io::prelude::Write, _col: tui::pretty::Column, width: usize) {
+        let _ = write!(
+            writer,
+            "{} {:width$}{} ",
+            self.name.to_string().bold(),
+            " ",
+            self.summary,
+        );
+    }
+}

--- a/moss/src/cli/sync.rs
+++ b/moss/src/cli/sync.rs
@@ -19,7 +19,7 @@ use thiserror::Error;
 
 use tui::dialoguer::theme::ColorfulTheme;
 use tui::dialoguer::Confirm;
-use tui::pretty::print_to_columns;
+use tui::pretty::autoprint_columns;
 
 pub fn command() -> Command {
     Command::new("sync")
@@ -98,13 +98,13 @@ pub fn handle(args: &ArgMatches, installation: Installation) -> Result<(), Error
     if !synced.is_empty() {
         println!("The following packages will be sync'd: ");
         println!();
-        print_to_columns(synced.as_slice());
+        autoprint_columns(synced.as_slice());
         println!();
     }
     if !removed.is_empty() {
         println!("The following orphaned packages will be removed: ");
         println!();
-        print_to_columns(removed.as_slice());
+        autoprint_columns(removed.as_slice());
         println!();
     }
 

--- a/moss/src/client/install.rs
+++ b/moss/src/client/install.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 use thiserror::Error;
 use tui::{
     dialoguer::{theme::ColorfulTheme, Confirm},
-    pretty::print_to_columns,
+    pretty::autoprint_columns,
 };
 
 use crate::{
@@ -60,7 +60,7 @@ pub fn install(client: &mut Client, pkgs: &[&str], yes: bool) -> Result<Timing, 
         if !installed.is_empty() {
             println!("The following package(s) are already installed:");
             println!();
-            print_to_columns(&installed);
+            autoprint_columns(&installed);
         }
 
         return Ok(timing);
@@ -68,7 +68,7 @@ pub fn install(client: &mut Client, pkgs: &[&str], yes: bool) -> Result<Timing, 
 
     println!("The following package(s) will be installed:");
     println!();
-    print_to_columns(&missing);
+    autoprint_columns(&missing);
     println!();
 
     // Must we prompt?

--- a/moss/src/client/prune.rs
+++ b/moss/src/client/prune.rs
@@ -12,7 +12,7 @@ use itertools::Itertools;
 use thiserror::Error;
 use tui::{
     dialoguer::{theme::ColorfulTheme, Confirm},
-    pretty::print_to_columns,
+    pretty::autoprint_columns,
 };
 
 use crate::{client::cache, db, environment, package, state, Installation, State};
@@ -125,7 +125,7 @@ pub fn prune(
     // Print out the states to be removed to the user
     println!("The following state(s) will be removed:");
     println!();
-    print_to_columns(&removals.iter().map(state::ColumnDisplay).collect::<Vec<_>>());
+    autoprint_columns(&removals.iter().map(state::ColumnDisplay).collect::<Vec<_>>());
     println!();
 
     let result = if yes {

--- a/moss/src/db/meta/mod.rs
+++ b/moss/src/db/meta/mod.rs
@@ -27,10 +27,11 @@ enum Table {
 }
 
 #[derive(Debug)]
-pub enum Filter {
+pub enum Filter<'a> {
     Provider(Provider),
     Dependency(Dependency),
     Name(package::Name),
+    Keyword(&'a str),
 }
 
 #[derive(Debug, Clone)]
@@ -154,6 +155,17 @@ impl Database {
                     .select(model::Meta::as_select())
                     .filter(model::meta::name.eq(name.to_string()))
                     .load_iter::<model::Meta, _>(conn)?,
+                Some(Filter::Keyword(keyword)) => {
+                    let pattern = format!("%{}%", keyword);
+                    model::meta::table
+                        .select(model::Meta::as_select())
+                        .filter(
+                            model::meta::name
+                                .like(pattern.clone())
+                                .or(model::meta::summary.like(pattern.clone())),
+                        )
+                        .load_iter::<model::Meta, _>(conn)?
+                }
                 None => model::meta::table
                     .select(model::Meta::as_select())
                     .load_iter::<model::Meta, _>(conn)?,
@@ -178,6 +190,18 @@ impl Database {
                     .inner_join(model::meta::table)
                     .filter(model::meta::name.eq(name.to_string()))
                     .load_iter::<model::License, _>(conn)?,
+                Some(Filter::Keyword(keyword)) => {
+                    let pattern = format!("%{}%", keyword);
+                    model::meta_licenses::table
+                        .select(model::License::as_select())
+                        .inner_join(model::meta::table)
+                        .filter(
+                            model::meta::name
+                                .like(pattern.clone())
+                                .or(model::meta::summary.like(pattern.clone())),
+                        )
+                        .load_iter::<model::License, _>(conn)?
+                }
                 None => model::meta_licenses::table
                     .select(model::License::as_select())
                     .load_iter::<model::License, _>(conn)?,
@@ -206,6 +230,18 @@ impl Database {
                     .inner_join(model::meta::table)
                     .filter(model::meta::name.eq(name.to_string()))
                     .load_iter::<model::Dependency, _>(conn)?,
+                Some(Filter::Keyword(keyword)) => {
+                    let pattern = format!("%{}%", keyword);
+                    model::meta_dependencies::table
+                        .select(model::Dependency::as_select())
+                        .inner_join(model::meta::table)
+                        .filter(
+                            model::meta::name
+                                .like(pattern.clone())
+                                .or(model::meta::summary.like(pattern.clone())),
+                        )
+                        .load_iter::<model::Dependency, _>(conn)?
+                }
                 None => model::meta_dependencies::table
                     .select(model::Dependency::as_select())
                     .load_iter::<model::Dependency, _>(conn)?,
@@ -234,6 +270,18 @@ impl Database {
                     .inner_join(model::meta::table)
                     .filter(model::meta::name.eq(name.to_string()))
                     .load_iter::<model::Provider, _>(conn)?,
+                Some(Filter::Keyword(keyword)) => {
+                    let pattern = format!("%{}%", keyword);
+                    model::meta_providers::table
+                        .select(model::Provider::as_select())
+                        .inner_join(model::meta::table)
+                        .filter(
+                            model::meta::name
+                                .like(pattern.clone())
+                                .or(model::meta::summary.like(pattern.clone())),
+                        )
+                        .load_iter::<model::Provider, _>(conn)?
+                }
                 None => model::meta_providers::table
                     .select(model::Provider::as_select())
                     .load_iter::<model::Provider, _>(conn)?,

--- a/moss/src/package/meta.rs
+++ b/moss/src/package/meta.rs
@@ -18,6 +18,12 @@ pub struct Id(pub(super) String);
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, AsRef, From, Into, Display)]
 pub struct Name(String);
 
+impl Name {
+    pub fn contains(&self, text: &str) -> bool {
+        self.0.contains(text)
+    }
+}
+
 /// The metadata of a [`Package`]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Meta {

--- a/moss/src/registry/mod.rs
+++ b/moss/src/registry/mod.rs
@@ -72,6 +72,10 @@ impl Registry {
         self.query(move |plugin| plugin.package(id))
     }
 
+    pub fn by_keyword<'a>(&'a self, keyword: &'a str, flags: package::Flags) -> impl Iterator<Item = Package> + 'a {
+        self.query(move |plugin| plugin.query_keyword(keyword, flags))
+    }
+
     /// Return a sorted stream of [`Package`] matching the given [`Flags`]
     ///
     /// [`Flags`]: package::Flags

--- a/moss/src/registry/plugin/active.rs
+++ b/moss/src/registry/plugin/active.rs
@@ -72,6 +72,10 @@ impl Active {
         self.query(flags, None)
     }
 
+    pub fn query_keyword(&self, keyword: &str, flags: package::Flags) -> Vec<Package> {
+        self.query(flags, Some(db::meta::Filter::Keyword(keyword)))
+    }
+
     /// Query all packages that match the given provider identity
     pub fn query_provider(&self, provider: &Provider, flags: package::Flags) -> Vec<Package> {
         self.query(flags, Some(db::meta::Filter::Provider(provider.clone())))

--- a/moss/src/registry/plugin/cobble.rs
+++ b/moss/src/registry/plugin/cobble.rs
@@ -69,6 +69,12 @@ impl Cobble {
         self.query(flags, |_| true)
     }
 
+    pub fn query_keyword(&self, keyword: &str, flags: package::Flags) -> Vec<Package> {
+        self.query(flags, |meta| {
+            meta.name.contains(keyword) || meta.summary.contains(keyword)
+        })
+    }
+
     pub fn query_provider(&self, provider: &Provider, flags: package::Flags) -> Vec<Package> {
         self.query(flags, |meta| meta.providers.contains(provider))
     }

--- a/moss/src/registry/plugin/mod.rs
+++ b/moss/src/registry/plugin/mod.rs
@@ -62,6 +62,17 @@ impl Plugin {
         })
     }
 
+    pub fn query_keyword(&self, keyword: &str, flags: package::Flags) -> package::Sorted<Vec<Package>> {
+        package::Sorted::new(match self {
+            Plugin::Active(plugin) => plugin.query_keyword(keyword, flags),
+            Plugin::Cobble(plugin) => plugin.query_keyword(keyword, flags),
+            Plugin::Repository(plugin) => plugin.query_keyword(keyword, flags),
+
+            #[cfg(test)]
+            Plugin::Test(plugin) => plugin.query_keyword(keyword, flags),
+        })
+    }
+
     /// Returns a list of packages with matching `provider` and `flags`
     pub fn query_provider(&self, provider: &Provider, flags: package::Flags) -> package::Sorted<Vec<Package>> {
         package::Sorted::new(match self {
@@ -143,6 +154,14 @@ pub mod test {
             self.packages
                 .iter()
                 .filter(|p| p.flags.contains(flags))
+                .cloned()
+                .collect()
+        }
+
+        pub fn query_keyword(&self, keyword: &str, flags: package::Flags) -> Vec<Package> {
+            self.packages
+                .iter()
+                .filter(|pkg| pkg.meta.name.contains(keyword) || pkg.meta.summary.contains(keyword))
                 .cloned()
                 .collect()
         }

--- a/moss/src/registry/plugin/repository.rs
+++ b/moss/src/registry/plugin/repository.rs
@@ -77,6 +77,10 @@ impl Repository {
         self.query(flags, None)
     }
 
+    pub fn query_keyword(&self, keyword: &str, flags: package::Flags) -> Vec<Package> {
+        self.query(flags, Some(db::meta::Filter::Keyword(keyword)))
+    }
+
     /// Query all packages that match the given provider identity
     pub fn query_provider(&self, provider: &Provider, flags: package::Flags) -> Vec<Package> {
         self.query(flags, Some(db::meta::Filter::Provider(provider.clone())))


### PR DESCRIPTION
First implementation step of #34.

Outputs:
```text
./target/debug/moss -D ~/Personal/SerpentOS/SOSROOT/ search gcc  -i
gcc       GNU C++ standard library and compiler 
```
```text
fforni@fedora:~/Personal/SerpentOS/moss$ ./target/debug/moss -D ~/Personal/SerpentOS/SOSROOT/ search gcc  
gcc-32bit-devel       Provides development files for gcc-32bit gcc-dbginfo                          Debugging symbols for gcc 
gcc-32bit            Provides 32-bit runtime libraries for gcc gcc                      GNU C++ standard library and compiler 
gcc-32bit-dbginfo              Debugging symbols for gcc-32bit gcc-devel                            Development files for gcc 
```

(Github destroyed the latter output. Inside a terminal it's well aligned). Also, package names are **bold**.

I'm not sure we should print 2 columns here. `moss search` output is supposed to be greppable I think.