### PR TITLE
boulder: include buildrel in jsonc manifest

### DIFF
--- a/boulder/src/package.rs
+++ b/boulder/src/package.rs
@@ -103,7 +103,7 @@ impl<'a> Packager<'a> {
             .collect::<Vec<_>>();
 
         // Emit package stones and manifest files to artefact directory
-        emit(self.paths, self.recipe, &packages).map_err(Error::Emit)?;
+        emit(self.paths, self.recipe, self.build_release, &packages).map_err(Error::Emit)?;
 
         timing.finish(timer);
 

--- a/boulder/src/package/emit.rs
+++ b/boulder/src/package/emit.rs
@@ -109,8 +109,8 @@ impl<'a> Ord for Package<'a> {
     }
 }
 
-pub fn emit(paths: &Paths, recipe: &Recipe, packages: &[Package]) -> Result<(), Error> {
-    let mut manifest = Manifest::new(paths, recipe, architecture::host());
+pub fn emit(paths: &Paths, recipe: &Recipe, build_release: NonZeroU64, packages: &[Package]) -> Result<(), Error> {
+    let mut manifest = Manifest::new(paths, recipe, build_release, architecture::host());
 
     println!("Packaging");
 

--- a/boulder/src/package/emit/manifest.rs
+++ b/boulder/src/package/emit/manifest.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use std::{collections::BTreeSet, io, path::PathBuf};
+use std::{collections::BTreeSet, io, num::NonZeroU64, path::PathBuf};
 
 use thiserror::Error;
 
@@ -16,6 +16,7 @@ mod json;
 #[derive(Debug)]
 pub struct Manifest<'a> {
     recipe: &'a Recipe,
+    build_release: NonZeroU64,
     arch: Architecture,
     output_dir: PathBuf,
     build_deps: BTreeSet<String>,
@@ -23,7 +24,7 @@ pub struct Manifest<'a> {
 }
 
 impl<'a> Manifest<'a> {
-    pub fn new(paths: &Paths, recipe: &'a Recipe, arch: Architecture) -> Self {
+    pub fn new(paths: &Paths, recipe: &'a Recipe, build_release: NonZeroU64, arch: Architecture) -> Self {
         let output_dir = paths.artefacts().guest;
 
         let build_deps = recipe
@@ -37,8 +38,9 @@ impl<'a> Manifest<'a> {
 
         Self {
             recipe,
-            output_dir,
+            build_release,
             arch,
+            output_dir,
             build_deps,
             packages: BTreeSet::new(),
         }
@@ -60,6 +62,7 @@ impl<'a> Manifest<'a> {
         json::write(
             &self.output_dir.join(format!("manifest.{}.jsonc", self.arch)),
             self.recipe,
+            self.build_release,
             &self.packages,
             &self.build_deps,
         )

--- a/boulder/src/package/emit/manifest/json.rs
+++ b/boulder/src/package/emit/manifest/json.rs
@@ -6,6 +6,7 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     fs::File,
     io::Write,
+    num::NonZeroU64,
     path::Path,
 };
 
@@ -18,6 +19,7 @@ use crate::{package::emit, Recipe};
 pub fn write(
     path: &Path,
     recipe: &Recipe,
+    build_release: NonZeroU64,
     packages: &BTreeSet<&emit::Package>,
     build_deps: &BTreeSet<String>,
 ) -> Result<(), Error> {
@@ -64,6 +66,7 @@ pub fn write(
         source_name: recipe.parsed.source.name.clone(),
         source_release: recipe.parsed.source.release.to_string(),
         source_version: recipe.parsed.source.version.clone(),
+        build_release,
     };
 
     let mut file = File::create(path)?;
@@ -88,8 +91,9 @@ struct Content {
     manifest_version: String,
     packages: BTreeMap<String, Package>,
     source_name: String,
-    source_release: String,
+    source_release: String, // FIXME: Refactor to NonZeroU64 on account of that's how we use it in practice?
     source_version: String,
+    build_release: NonZeroU64,
 }
 
 #[derive(Serialize)]

--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@
 default: moss
 
 root-dir := justfile_directory()
-build-mode := env_var_or_default("MODE", "release")
+build-mode := env_var_or_default("MODE", "packaging")
 
 [private]
 help:


### PR DESCRIPTION
This makes it easier to see when `boulder build -bN` has been used to build a set of artefacts.

Example:

```diff
diff --git a/x/xorriso/manifest.x86_64.jsonc b/x/xorriso/manifest.x86_64.jsonc
index e535ffc3..baef6688 100644
--- a/x/xorriso/manifest.x86_64.jsonc
+++ b/x/xorriso/manifest.x86_64.jsonc
@@ -38,5 +38,6 @@
        },
        "source-name": "xorriso",
        "source-release": "1",
-       "source-version": "1.5.6.pl02"
+       "source-version": "1.5.6.pl02",
+       "build-release": 2
 }

```