### PR TITLE
boulder: Fix emul32 incompatibility with dlang boulder

### DIFF
--- a/boulder/Cargo.toml
+++ b/boulder/Cargo.toml
@@ -5,6 +5,14 @@ edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+# See https://github.com/serpent-os/moss/issues/231 for details
+default = ["compat_dlang_emul_both"]
+# In this mode we create duplicate provides for both `386` and `x86` while depending on `x86`
+compat_dlang_emul_both = []
+# In this mode we create duplicate provides for both `386` and `x86` while depending on `386`
+compat_dlang_emul_flush = []
+
 [dependencies]
 config = { path = "../crates/config" }
 container = { path = "../crates/container" }


### PR DESCRIPTION
The Rust elf library returns `EM_386` for x86 ELF objects, while we used `x86` as the ISA with the dlang boulder. This results in emul32 packages that are not compatible with packages already in the volatile repo.

To "Fix" this make sure we use `x86` for all dependencies, while also adding each dependency twice as both `x86` and `386`. This ensures that newly built packages are compatible with existing ones while also allowing us to switch fully to `386` once every existing emul32 package has been rebuilt. We can also just drop the duplicate `386` provide if we decide to use `x86` instead without any repo issues.