### PR TITLE
Ensure git hash is up-to-date for boulder

### DIFF
--- a/crates/stone/src/read/mod.rs
+++ b/crates/stone/src/read/mod.rs
@@ -45,7 +45,7 @@ impl<R: Read + Seek> Reader<R> {
             .flat_map(|_| PayloadKind::decode(&mut self.reader, &mut self.hasher).transpose()))
     }
 
-    pub fn unpack_content<W: Write>(&mut self, content: &Payload<Content>, writer: &mut W) -> Result<(), Error>
+    pub fn unpack_content<W>(&mut self, content: &Payload<Content>, writer: &mut W) -> Result<(), Error>
     where
         W: Write,
     {

--- a/crates/vfs/src/tree/builder.rs
+++ b/crates/vfs/src/tree/builder.rs
@@ -104,7 +104,7 @@ impl<T: BlitFile> TreeBuilder<T> {
                         target
                     }
                 };
-                if all_dirs.get(&target).is_some() {
+                if all_dirs.contains_key(&target) {
                     redirects.insert(path, target);
                 }
             }

--- a/moss/build.rs
+++ b/moss/build.rs
@@ -5,9 +5,8 @@ fn main() {
         println!("cargo:rustc-env=GIT_HASH={}", hash);
     }
 
-    println!("cargo:rerun-if-changed=src/db/meta/migrations/");
-    println!("cargo:rerun-if-changed=src/db/layout/migrations/");
-    println!("cargo:rerun-if-changed=src/db/state/migrations/");
+    println!("cargo:rerun-if-changed=../boulder/src");
+    println!("cargo:rerun-if-changed=../Cargo.lock");
 }
 
 fn git_hash() -> Result<String, Box<dyn std::error::Error>> {

--- a/moss/src/client/mod.rs
+++ b/moss/src/client/mod.rs
@@ -9,6 +9,7 @@
 //! operations
 
 use std::{
+    fmt,
     fs::{self, create_dir_all},
     io,
     os::{fd::RawFd, unix::fs::symlink},
@@ -833,9 +834,9 @@ impl From<String> for PendingFile {
     }
 }
 
-impl ToString for PendingFile {
-    fn to_string(&self) -> String {
-        self.path()
+impl fmt::Display for PendingFile {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.path().fmt(f)
     }
 }
 


### PR DESCRIPTION
All files under `src` are already rerun-if-changed by default, so those lines can be removed.

The new directives ensure that the moss build script is always recompiled if boulder or cargo lock changes. This should ensure that the boulder binary always has the latest commit SHA even if the underlying moss library did not change.