### PR TITLE
all: Switch to deterministic BTreeMap/BTreeSet

### DIFF
--- a/boulder/src/architecture.rs
+++ b/boulder/src/architecture.rs
@@ -37,7 +37,7 @@ impl Architecture {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Display)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Display)]
 pub enum BuildTarget {
     #[display(fmt = "{_0}")]
     Native(Architecture),

--- a/boulder/src/build/job/phase.rs
+++ b/boulder/src/build/job/phase.rs
@@ -2,20 +2,20 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use std::collections::HashSet;
-
 use itertools::Itertools;
+use std::collections::BTreeSet;
+
 use stone_recipe::{
     script,
     tuning::{self, Toolchain},
     Script,
 };
-
 use tui::Styled;
 
-use super::{work_dir, Error};
 use crate::build::pgo;
 use crate::{architecture::BuildTarget, util, Macros, Paths, Recipe};
+
+use super::{work_dir, Error};
 
 pub fn list(pgo_stage: Option<pgo::Stage>) -> Vec<Phase> {
     if matches!(pgo_stage, Some(pgo::Stage::One | pgo::Stage::Two)) {
@@ -25,7 +25,7 @@ pub fn list(pgo_stage: Option<pgo::Stage>) -> Vec<Phase> {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, strum::Display)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, strum::Display)]
 pub enum Phase {
     Prepare,
     Setup,
@@ -316,7 +316,7 @@ fn add_tuning(
         flags
             .map(|s| s.trim())
             .filter(|s| s.len() > 1)
-            .collect::<HashSet<_>>()
+            .collect::<BTreeSet<_>>()
             .into_iter()
             .join(" ")
     }

--- a/boulder/src/build/pgo.rs
+++ b/boulder/src/build/pgo.rs
@@ -23,7 +23,7 @@ pub fn stages(recipe: &Recipe, target: BuildTarget) -> Option<Vec<Stage>> {
     })
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, strum::Display)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, strum::Display)]
 pub enum Stage {
     #[strum(serialize = "stage1")]
     One,

--- a/boulder/src/build/root.rs
+++ b/boulder/src/build/root.rs
@@ -2,12 +2,13 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 use std::{fs, io};
+
+use thiserror::Error;
 
 use moss::{repository, runtime, Installation};
 use stone_recipe::{tuning::Toolchain, Upstream};
-use thiserror::Error;
 
 use crate::build::Builder;
 use crate::{container, timing, util, Timing};
@@ -149,7 +150,7 @@ fn packages(builder: &Builder) -> Vec<&str> {
         .into_iter()
         .chain(extra_deps)
         // Remove dupes
-        .collect::<HashSet<_>>()
+        .collect::<BTreeSet<_>>()
         .into_iter()
         .collect()
 }

--- a/boulder/src/cli/profile.rs
+++ b/boulder/src/cli/profile.rs
@@ -2,14 +2,15 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use std::{collections::HashMap, io};
+use std::{collections::BTreeMap, io};
 
-use boulder::{profile, Env, Profile};
 use clap::Parser;
 use itertools::Itertools;
-use moss::{repository, runtime, Installation, Repository};
 use thiserror::Error;
 use url::Url;
+
+use boulder::{profile, Env, Profile};
+use moss::{repository, runtime, Installation, Repository};
 
 #[derive(Debug, Parser)]
 #[command(about = "Manage boulder profiles")]
@@ -27,13 +28,13 @@ pub enum Subcommand {
         #[arg(help = "profile name")]
         name: String,
         #[arg(
-            short = 'r',
-            long = "repo",
-            required = true,
-            help = "profile repositories",
-            value_parser = parse_repository,
-            help = "repository to add to profile, can be passed multiple times",
-            long_help = "repository to add to profile\n\nExample: --repo name=volatile,uri=https://dev.serpentos.com/volatile/x86_64/stone.index,priority=100"
+        short = 'r',
+        long = "repo",
+        required = true,
+        help = "profile repositories",
+        value_parser = parse_repository,
+        help = "repository to add to profile, can be passed multiple times",
+        long_help = "repository to add to profile\n\nExample: --repo name=volatile,uri=https://dev.serpentos.com/volatile/x86_64/stone.index,priority=100"
         )]
         repos: Vec<(repository::Id, Repository)>,
     },
@@ -49,7 +50,7 @@ fn parse_repository(s: &str) -> Result<(repository::Id, Repository), String> {
     let key_values = s
         .split(',')
         .filter_map(|kv| kv.split_once('='))
-        .collect::<HashMap<_, _>>();
+        .collect::<BTreeMap<_, _>>();
 
     let id = repository::Id::new(key_values.get("name").ok_or("missing name")?.to_string());
     let uri = key_values
@@ -140,6 +141,7 @@ pub fn update<'a>(env: &'a Env, manager: profile::Manager<'a>, profile: &profile
 
     Ok(())
 }
+
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("config")]

--- a/boulder/src/draft/build.rs
+++ b/boulder/src/draft/build.rs
@@ -1,11 +1,8 @@
 // SPDX-FileCopyrightText: Copyright © 2020-2024 Serpent OS Developers
 //
 // SPDX-License-Identifier: MPL-2.0
-use std::{
-    collections::{HashMap, HashSet},
-    fmt,
-    num::NonZeroU64,
-};
+use std::collections::{BTreeMap, BTreeSet};
+use std::{fmt, num::NonZeroU64};
 
 use moss::Dependency;
 
@@ -20,7 +17,7 @@ mod python;
 pub type Error = Box<dyn std::error::Error>;
 
 /// A build system
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, strum::Display)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Ord, PartialOrd, strum::Display)]
 #[strum(serialize_all = "lowercase")]
 pub enum System {
     Autotools,
@@ -102,7 +99,7 @@ impl fmt::Display for Phases {
 /// State passed to each system when processing paths
 struct State<'a> {
     /// Any dependencies that need to be recorded
-    dependencies: &'a mut HashSet<Dependency>,
+    dependencies: &'a mut BTreeSet<Dependency>,
     /// Total confidence level of the current build [`System`]
     confidence: u64,
 }
@@ -124,14 +121,14 @@ pub struct Analysis {
     /// The detected build [`System`], if any
     pub detected_system: Option<System>,
     /// All detected dependencies
-    pub dependencies: HashSet<Dependency>,
+    pub dependencies: BTreeSet<Dependency>,
 }
 
 /// Analyze the provided paths to determine which build [`System`]
 /// the project uses and any dependencies that are identified
 pub fn analyze(files: &[File]) -> Result<Analysis, Error> {
-    let mut dependencies = HashSet::new();
-    let mut confidences = HashMap::new();
+    let mut dependencies = BTreeSet::new();
+    let mut confidences = BTreeMap::new();
 
     for system in System::ALL {
         let mut state = State {

--- a/boulder/src/macros.rs
+++ b/boulder/src/macros.rs
@@ -2,7 +2,8 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use std::{collections::HashMap, fs, io, path::Path};
+use std::collections::BTreeMap;
+use std::{fs, io, path::Path};
 
 use thiserror::Error;
 
@@ -10,7 +11,7 @@ use crate::{util, Env};
 
 #[derive(Debug)]
 pub struct Macros {
-    pub arch: HashMap<String, stone_recipe::Macros>,
+    pub arch: BTreeMap<String, stone_recipe::Macros>,
     pub actions: Vec<stone_recipe::Macros>,
 }
 
@@ -25,7 +26,7 @@ impl Macros {
         let arch_files = util::enumerate_files(&arch_dir, matcher).map_err(Error::ArchFiles)?;
         let action_files = util::enumerate_files(&actions_dir, matcher).map_err(Error::ActionFiles)?;
 
-        let mut arch = HashMap::new();
+        let mut arch = BTreeMap::new();
         let mut actions = vec![];
 
         for file in arch_files {

--- a/boulder/src/package/analysis.rs
+++ b/boulder/src/package/analysis.rs
@@ -2,8 +2,9 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
+use std::collections::BTreeMap;
 use std::{
-    collections::{BTreeSet, HashMap, VecDeque},
+    collections::{BTreeSet, VecDeque},
     path::PathBuf,
 };
 
@@ -11,8 +12,9 @@ use moss::{Dependency, Provider};
 use stone::write::digest;
 use tui::{ProgressBar, ProgressStyle, Styled};
 
-use super::collect::{Collector, PathInfo};
 use crate::{Paths, Recipe};
+
+use super::collect::{Collector, PathInfo};
 
 mod handler;
 
@@ -24,7 +26,7 @@ pub struct Chain<'a> {
     paths: &'a Paths,
     collector: &'a Collector,
     hasher: &'a mut digest::Hasher,
-    pub buckets: HashMap<String, Bucket>,
+    pub buckets: BTreeMap<String, Bucket>,
 }
 
 impl<'a> Chain<'a> {

--- a/boulder/src/profile.rs
+++ b/boulder/src/profile.rs
@@ -2,19 +2,19 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use std::collections::HashMap;
+use derive_more::Display;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use thiserror::Error;
 
 use config::Config;
-use derive_more::Display;
 use moss::repository;
 pub use moss::{repository::Priority, Repository};
-use serde::{Deserialize, Serialize};
-use thiserror::Error;
 
 use crate::Env;
 
 /// A unique [`Profile`] identifier
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Display)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Ord, PartialOrd, Display)]
 #[serde(from = "String")]
 pub struct Id(String);
 
@@ -43,7 +43,7 @@ pub struct Profile {
 
 /// A map of profiles
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct Map(HashMap<Id, Profile>);
+pub struct Map(BTreeMap<Id, Profile>);
 
 impl Map {
     pub fn is_empty(&self) -> bool {
@@ -73,7 +73,7 @@ impl Map {
 
 impl IntoIterator for Map {
     type Item = (Id, Profile);
-    type IntoIter = std::collections::hash_map::IntoIter<Id, Profile>;
+    type IntoIter = std::collections::btree_map::IntoIter<Id, Profile>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()

--- a/crates/fnmatch/src/lib.rs
+++ b/crates/fnmatch/src/lib.rs
@@ -14,15 +14,13 @@
 //!     let result = pattern.match_path("/usr/lib/modules/6.2.3/kernel").expect("no kernel match");
 //! ```
 
-use std::{
-    collections::{HashMap, HashSet},
-    convert::Infallible,
-    str::FromStr,
-};
+use std::collections::{BTreeMap, BTreeSet};
+use std::{convert::Infallible, str::FromStr};
 
 use regex::Regex;
 use serde::{de, Deserialize};
 use thiserror::Error;
+
 #[derive(Debug)]
 enum Fragment {
     /// `?`
@@ -116,7 +114,7 @@ pub struct Match {
     pub path: String,
 
     /// Captured variables, as defined by the [`Pattern::groups()`]
-    pub variables: HashMap<String, String>,
+    pub variables: BTreeMap<String, String>,
 }
 
 impl Pattern {
@@ -243,7 +241,7 @@ impl FromStr for Pattern {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let fragments = fragments_from_string(s)?;
-        let mut groups = HashSet::new();
+        let mut groups = BTreeSet::new();
 
         let compiled = fragments
             .iter()

--- a/crates/stone_recipe/src/tuning.rs
+++ b/crates/stone_recipe/src/tuning.rs
@@ -2,9 +2,8 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use std::collections::{HashMap, HashSet};
-
 use serde::Deserialize;
+use std::collections::{BTreeMap, BTreeSet};
 use thiserror::Error;
 
 use crate::{sequence_of_key_value, single_as_sequence, KeyValue, Macros};
@@ -32,7 +31,7 @@ impl<'de> Deserialize<'de> for KeyValue<Tuning> {
         #[serde(untagged)]
         enum Outer {
             Key(String),
-            KeyValue(HashMap<String, Inner>),
+            KeyValue(BTreeMap<String, Inner>),
         }
 
         match Outer::deserialize(deserializer)? {
@@ -134,11 +133,11 @@ pub struct TuningGroup {
 
 #[derive(Debug, Default)]
 pub struct Builder {
-    flags: HashMap<String, TuningFlag>,
-    groups: HashMap<String, TuningGroup>,
-    enabled: HashSet<String>,
-    disabled: HashSet<String>,
-    option_sets: HashMap<String, String>,
+    flags: BTreeMap<String, TuningFlag>,
+    groups: BTreeMap<String, TuningGroup>,
+    enabled: BTreeSet<String>,
+    disabled: BTreeSet<String>,
+    option_sets: BTreeMap<String, String>,
 }
 
 impl Builder {
@@ -200,8 +199,8 @@ impl Builder {
     }
 
     pub fn build(&self) -> Result<Vec<TuningFlag>, Error> {
-        let mut enabled_flags = HashSet::new();
-        let mut disabled_flags = HashSet::new();
+        let mut enabled_flags = BTreeSet::new();
+        let mut disabled_flags = BTreeSet::new();
 
         for enabled in &self.enabled {
             let Some(group) = self.groups.get(enabled) else {
@@ -235,7 +234,7 @@ impl Builder {
         Ok(enabled_flags
             .iter()
             .chain(&disabled_flags)
-            .collect::<HashSet<_>>()
+            .collect::<BTreeSet<_>>()
             .into_iter()
             .filter_map(|flag| self.flags.get(flag).cloned())
             .collect())

--- a/crates/vfs/src/tree/builder.rs
+++ b/crates/vfs/src/tree/builder.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //! Build a vfs tree incrementally
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 use crate::path;
 use crate::tree::{Kind, Tree};
@@ -86,7 +86,7 @@ impl<T: BlitFile> TreeBuilder<T> {
             .collect::<BTreeMap<_, _>>();
 
         // build a set of redirects
-        let mut redirects = HashMap::new();
+        let mut redirects = BTreeMap::new();
 
         // Resolve symlinks-to-dirs
         for link in self.explicit.iter() {
@@ -140,8 +140,9 @@ impl<T: BlitFile> TreeBuilder<T> {
 
 #[cfg(test)]
 mod tests {
-    use super::{BlitFile, TreeBuilder};
     use crate::tree::Kind;
+
+    use super::{BlitFile, TreeBuilder};
 
     #[derive(Clone, Default, Debug, PartialEq, Eq, PartialOrd, Ord)]
     struct CustomFile {

--- a/crates/vfs/src/tree/mod.rs
+++ b/crates/vfs/src/tree/mod.rs
@@ -5,7 +5,8 @@
 //! Virtual filesystem tree (optimise layout inserts)
 
 use core::fmt::Debug;
-use std::{collections::HashMap, vec};
+use std::collections::BTreeMap;
+use std::vec;
 
 use indextree::{Arena, Descendants, NodeId};
 use thiserror::Error;
@@ -42,7 +43,7 @@ pub trait BlitFile: Clone + Sized + Debug + From<String> {
 #[derive(Debug)]
 pub struct Tree<T: BlitFile> {
     arena: Arena<T>,
-    map: HashMap<String, NodeId>,
+    map: BTreeMap<String, NodeId>,
     length: u64,
 }
 
@@ -51,7 +52,7 @@ impl<T: BlitFile> Tree<T> {
     fn new() -> Self {
         Tree {
             arena: Arena::new(),
-            map: HashMap::new(),
+            map: BTreeMap::new(),
             length: 0_u64,
         }
     }
@@ -106,7 +107,7 @@ impl<T: BlitFile> Tree<T> {
                 // Report duplicate and skip for now
                 eprintln!(
                     "error: {}",
-                    Error::Duplicate(node.get().path(), node.get().id(), others.first().unwrap().id(),)
+                    Error::Duplicate(node.get().path(), node.get().id(), others.first().unwrap().id())
                 );
 
                 Ok(())

--- a/moss/src/client/cache.rs
+++ b/moss/src/client/cache.rs
@@ -4,15 +4,14 @@
 
 //! Cache management for unpacking remote assets (`.stone`, etc.)
 
+use std::collections::BTreeSet;
 use std::{
-    collections::HashSet,
     io,
     path::PathBuf,
     sync::{Arc, Mutex},
 };
 
 use futures::StreamExt;
-use stone::{payload, read::PayloadKind};
 use thiserror::Error;
 use tokio::{
     fs::{self, File},
@@ -20,13 +19,15 @@ use tokio::{
 };
 use url::Url;
 
+use stone::{payload, read::PayloadKind};
+
 use crate::{package, request, Installation};
 
 /// Synchronized set of assets that are currently being
 /// unpacked. Used to prevent unpacking the same asset
 /// from different packages at the same time.
 #[derive(Debug, Clone, Default)]
-pub struct UnpackingInProgress(Arc<Mutex<HashSet<PathBuf>>>);
+pub struct UnpackingInProgress(Arc<Mutex<BTreeSet<PathBuf>>>);
 
 impl UnpackingInProgress {
     /// Marks the provided path as "in-progress".

--- a/moss/src/client/prune.rs
+++ b/moss/src/client/prune.rs
@@ -8,14 +8,15 @@
 //! system states (i.e. historical snapshots) that cleans up database entries
 //! and assets on disk by way of refcounting.
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::{
-    collections::{HashMap, HashSet},
     fs, io,
     path::{Path, PathBuf},
 };
 
 use itertools::Itertools;
 use thiserror::Error;
+
 use tui::{
     dialoguer::{theme::ColorfulTheme, Confirm},
     pretty::autoprint_columns,
@@ -101,7 +102,7 @@ pub fn prune(
     }
 
     // Keep track of how many active states are using a package
-    let mut packages_counts = HashMap::<package::Id, usize>::new();
+    let mut packages_counts = BTreeMap::<package::Id, usize>::new();
     let mut removals = vec![];
 
     // Get net refcount of each package in all states
@@ -226,7 +227,7 @@ fn prune_databases(
 /// Removes all files under `root` that no longer exist in the provided `final_hashes` set
 fn remove_orphaned_files(
     root: PathBuf,
-    final_hashes: HashSet<String>,
+    final_hashes: BTreeSet<String>,
     compute_path: impl Fn(String) -> Option<PathBuf>,
 ) -> Result<(), Error> {
     // Compute hashes to remove by (installed - final)
@@ -258,7 +259,7 @@ fn remove_orphaned_files(
 }
 
 /// Returns all nested files under `root` and parses the file name as a hash
-fn enumerate_file_hashes(root: impl AsRef<Path>) -> Result<HashSet<String>, io::Error> {
+fn enumerate_file_hashes(root: impl AsRef<Path>) -> Result<BTreeSet<String>, io::Error> {
     let files = enumerate_files(root)?;
 
     let path_to_hash = |path: PathBuf| {

--- a/moss/src/client/verify.rs
+++ b/moss/src/client/verify.rs
@@ -2,13 +2,10 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use std::{
-    collections::{BTreeSet, HashSet},
-    fmt, fs, io,
-    path::PathBuf,
-};
+use std::{collections::BTreeSet, fmt, fs, io, path::PathBuf};
 
 use itertools::Itertools;
+
 use stone::{payload::layout, write::digest};
 use tui::{
     dialoguer::{theme::ColorfulTheme, Confirm},
@@ -194,7 +191,7 @@ pub fn verify(client: &Client, yes: bool, verbose: bool) -> Result<(), client::E
             .iter()
             .filter_map(Issue::packages)
             .flatten()
-            .collect::<HashSet<_>>(),
+            .collect::<BTreeSet<_>>(),
     )?;
 
     // We had some corrupt or missing assets, let's resolve that!
@@ -268,12 +265,12 @@ enum Issue {
     CorruptAsset {
         hash: String,
         files: BTreeSet<String>,
-        packages: HashSet<package::Id>,
+        packages: BTreeSet<package::Id>,
     },
     MissingAsset {
         hash: String,
         files: BTreeSet<String>,
-        packages: HashSet<package::Id>,
+        packages: BTreeSet<package::Id>,
     },
     MissingVFSPath {
         path: PathBuf,
@@ -290,7 +287,7 @@ impl Issue {
         }
     }
 
-    fn packages(&self) -> Option<&HashSet<package::Id>> {
+    fn packages(&self) -> Option<&BTreeSet<package::Id>> {
         match self {
             Issue::CorruptAsset { packages, .. } | Issue::MissingAsset { packages, .. } => Some(packages),
             Issue::MissingVFSPath { .. } => None,

--- a/moss/src/db/layout/mod.rs
+++ b/moss/src/db/layout/mod.rs
@@ -2,16 +2,16 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use std::collections::HashSet;
-
 use diesel::prelude::*;
 use diesel::{Connection as _, SqliteConnection};
 use diesel_migrations::{embed_migrations, EmbeddedMigrations, MigrationHarness};
+use std::collections::BTreeSet;
+
 use stone::payload;
 
-use super::Connection;
 use crate::package;
 
+use super::Connection;
 pub use super::Error;
 
 const MIGRATIONS: EmbeddedMigrations = embed_migrations!("src/db/layout/migrations");
@@ -61,7 +61,7 @@ impl Database {
         })
     }
 
-    pub fn file_hashes(&self) -> Result<HashSet<String>, Error> {
+    pub fn file_hashes(&self) -> Result<BTreeSet<String>, Error> {
         self.conn.exec(|conn| {
             let hashes = model::layout::table
                 .select(model::layout::entry_value1.assume_not_null())

--- a/moss/src/db/meta/mod.rs
+++ b/moss/src/db/meta/mod.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 
 use diesel::prelude::*;
 use diesel::{Connection as _, SqliteConnection};
@@ -133,7 +133,7 @@ impl Database {
                 ))
             };
 
-            let mut entries: HashMap<package::Id, Meta> = match &filter {
+            let mut entries: BTreeMap<package::Id, Meta> = match &filter {
                 Some(Filter::Provider(provider)) => model::meta::table
                     .select(model::Meta::as_select())
                     .inner_join(model::meta_providers::table)
@@ -212,7 +212,7 @@ impl Database {
         })
     }
 
-    pub fn file_hashes(&self) -> Result<HashSet<String>, Error> {
+    pub fn file_hashes(&self) -> Result<BTreeSet<String>, Error> {
         self.conn.exec(|conn| {
             Ok(model::meta::table
                 .select(model::meta::hash.assume_not_null())

--- a/moss/src/package/meta.rs
+++ b/moss/src/package/meta.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 use crate::{dependency, Dependency, Provider};
 
 /// A package identifier constructed from metadata fields
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Display)]
+#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Display)]
 pub struct Id(pub(super) String);
 
 /// The name of a [`super::Package`]

--- a/moss/src/registry/mod.rs
+++ b/moss/src/registry/mod.rs
@@ -109,7 +109,7 @@ impl Registry {
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashSet;
+    use std::collections::BTreeSet;
 
     use super::*;
 
@@ -213,8 +213,8 @@ mod test {
             let actual = actual
                 .into_iter()
                 .map(|p| String::from(p.meta.name))
-                .collect::<HashSet<_>>();
-            let expected = expected.iter().map(|s| s.to_string()).collect::<HashSet<_>>();
+                .collect::<BTreeSet<_>>();
+            let expected = expected.iter().map(|s| s.to_string()).collect::<BTreeSet<_>>();
 
             actual == expected
         }

--- a/moss/src/registry/plugin/cobble.rs
+++ b/moss/src/registry/plugin/cobble.rs
@@ -2,20 +2,23 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
+use std::collections::BTreeMap;
 use std::fs::File;
 use std::io;
-use std::{collections::HashMap, path::PathBuf};
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+use stone::read::PayloadKind;
 
 use crate::package::{self, meta, Meta, MissingMetaFieldError, Package};
 use crate::Provider;
-use stone::read::PayloadKind;
-use thiserror::Error;
 
 // TODO:
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct Cobble {
     // Storage of local packages
-    packages: HashMap<meta::Id, State>,
+    packages: BTreeMap<meta::Id, State>,
 }
 
 impl Cobble {

--- a/moss/src/repository/manager.rs
+++ b/moss/src/repository/manager.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fs::{self, File};
 use std::io;
 use std::path::{Path, PathBuf};
@@ -11,14 +11,14 @@ use std::time::Duration;
 use futures::{stream, StreamExt, TryStreamExt};
 use itertools::Itertools;
 use thiserror::Error;
-use tui::{MultiProgress, ProgressBar, ProgressStyle, Styled};
 use xxhash_rust::xxh3::xxh3_64;
 
+use tui::{MultiProgress, ProgressBar, ProgressStyle, Styled};
+
 use crate::db::meta;
+use crate::repository::{self, Repository};
 use crate::{environment, runtime};
 use crate::{package, Installation};
-
-use crate::repository::{self, Repository};
 
 enum Source {
     System(config::Manager),
@@ -38,7 +38,7 @@ impl Source {
 pub struct Manager {
     source: Source,
     installation: Installation,
-    repositories: HashMap<repository::Id, repository::Active>,
+    repositories: BTreeMap<repository::Id, repository::Active>,
 }
 
 impl Manager {

--- a/moss/src/repository/mod.rs
+++ b/moss/src/repository/mod.rs
@@ -2,9 +2,9 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use std::{collections::HashMap, path::Path};
+use std::collections::BTreeMap;
+use std::path::Path;
 
-use config::Config;
 use derive_more::{Display, From, Into};
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
@@ -15,6 +15,8 @@ use tokio::{
 };
 use url::Url;
 
+use config::Config;
+
 use crate::{db::meta, request};
 
 pub use self::manager::Manager;
@@ -22,7 +24,7 @@ pub use self::manager::Manager;
 pub mod manager;
 
 /// A unique [`Repository`] identifier
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, From, Display)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Ord, PartialOrd, From, Display)]
 #[serde(from = "String")]
 pub struct Id(String);
 
@@ -78,7 +80,7 @@ impl Ord for Priority {
 
 /// A map of repositories
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct Map(HashMap<Id, Repository>);
+pub struct Map(BTreeMap<Id, Repository>);
 
 impl Map {
     pub fn with(items: impl IntoIterator<Item = (Id, Repository)>) -> Self {
@@ -104,7 +106,7 @@ impl Map {
 
 impl IntoIterator for Map {
     type Item = (Id, Repository);
-    type IntoIter = std::collections::hash_map::IntoIter<Id, Repository>;
+    type IntoIter = std::collections::btree_map::IntoIter<Id, Repository>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()


### PR DESCRIPTION
While testing ccache I noticed that cache hit rate was extremely low. After some debugging I noticed that the CFLAGS and other environmental variables and macro scripts were not being set deterministically. This is problematic for ccache as it hashes the compiler arguments as part of the key and the order matters to get the same key on a future run.

The cause of this non-determinism is the Rust stdlib HashMap and HashSet, for which the default hasher used a random seed. To solve this switch to BTreeMap and BTreeSet from the stdlib. Since non-determinism is just generally a bad idea for build tools and package management software replace ALL uses of HashMap and HashSet repo-wide.

Tested by building a package with ccache enabled and using `ccache --show-stats` in the package recipe to verify that the hit rate was now 100% and that the build stage time had dropped to just the time it spent linking.