### PR TITLE
boulder: Add SOURCE_DATE_EPOCH

### DIFF
--- a/boulder/data/macros/arch/base.yaml
+++ b/boulder/data/macros/arch/base.yaml
@@ -58,6 +58,7 @@ actions              :
             set -e
             set -x
             TERM="dumb"; export TERM
+            SOURCE_DATE_EPOCH="%(sourcedateepoch)"; export SOURCE_DATE_EPOCH
             PKG_CONFIG_PATH="%(pkgconfigpath)"; export PKG_CONFIG_PATH
             CFLAGS="%(cflags)"; export CFLAGS
             CGO_CFLAGS="%(cflags)"; export CGO_CFLAGS

--- a/boulder/src/build/job/phase.rs
+++ b/boulder/src/build/job/phase.rs
@@ -150,6 +150,8 @@ impl Phase {
 
         parser.add_definition("compiler_cache", "/mason/ccache");
 
+        parser.add_definition("sourcedateepoch", recipe.build_time.timestamp());
+
         let path = if ccache {
             "/usr/lib/ccache/bin:/usr/bin:/bin"
         } else {


### PR DESCRIPTION
Wire up SOURCE_DATE_EPOCH. This environmental variable will always be set in the buildroot and will be set according to the following priority:
- Check to see if the environmental variable is already set, if so propagate it
- Check the return value of `git log -1 --format="%at"`, which returns the timestamp of the last commit of the git repo
- Use the current time