### PR TITLE
repo: Add default rust flags

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,22 @@
+[target."x86_64-unknown-linux-gnu"]
+# - On systems that do not use lld as the system linker (such as Solus) using lld directly saves about a second 
+# of build time for incremental compiles for building boulder (from 2.191s to 1.198s on my machine).
+# - Compressing debug symbols with zstd shrinks the dev profile boulder binary from 206.03MB to 81.44MB, a 124.59MB
+# or ~60% savings. It doesn't affect the binary size for packaging builds since we strip those, but the debug symbols
+# are reduced in size from 113.16MB to 34.63MB. It adds about ~152ms to the build times which is less than we gained 
+# by switching to lld
+# - The new symbol mangling format (https://doc.rust-lang.org/rustc/symbol-mangling/v0.html) improves the backtrace
+# shown by RUST_BACKTRACE=1 and other debug utilities. It should also be helpful once we have ABI reports. Upstream
+# hasn't switched to it yet by default due to stable distros not having new enough tools, but that doesn't matter for us
+rustflags = [
+    "-Clink-arg=-fuse-ld=lld",
+    "-Clink-arg=-Wl,--compress-debug-sections=zstd",
+    "-Csymbol-mangling-version=v0",
+]
+
+[target."aarch64-unknown-linux-gnu"]
+rustflags = [
+    "-Clink-arg=-fuse-ld=lld",
+    "-Clink-arg=-Wl,--compress-debug-sections=zstd",
+    "-Csymbol-mangling-version=v0",
+]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,14 @@ jobs:
     - name: typos-action
       uses: crate-ci/typos@v1.20.8
 
+    - name: Install LLVM and Clang
+      run: |
+        wget https://apt.llvm.org/llvm.sh
+        chmod +x llvm.sh
+        sudo ./llvm.sh 18
+        echo "/usr/lib/llvm-18/bin" >> $GITHUB_PATH
+        echo "CC=/usr/lib/llvm-18/bin/clang" >> $GITHUB_ENV
+
     - name: Install Rust
       uses: dtolnay/rust-toolchain@stable
       with:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -22,6 +22,14 @@ jobs:
     - name: Install musl
       run: sudo apt-get install musl-tools
 
+    - name: Install LLVM and Clang
+      run: |
+        wget https://apt.llvm.org/llvm.sh
+        chmod +x llvm.sh
+        sudo ./llvm.sh 18
+        echo "/usr/lib/llvm-18/bin" >> $GITHUB_PATH
+        echo "CC=/usr/lib/llvm-18/bin/clang" >> $GITHUB_ENV
+
     - name: Install Rust
       uses: dtolnay/rust-toolchain@nightly
       with:


### PR DESCRIPTION
Flags:
- Use lld even on distros that do not use lld for the system linker (like Solus) to speed up builds, especially incremental ones
- Compress debug symbols with zstd for significant space savings
- Enable the new system mangler format for improved ABI reports