### PR TITLE
all: Use stdlib OnceLock for HTTP client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1263,7 +1263,6 @@ dependencies = [
  "libsqlite3-sys",
  "log",
  "nix",
- "once_cell",
  "rayon",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ libsqlite3-sys = { version = "0.28.0", features = ["bundled"] }
 log = "0.4"
 nom = "7.1.3"
 nix = { version = "0.27.1", features = ["user", "fs", "sched", "process", "mount", "hostname", "signal", "term"] }
-once_cell = "1.19.0"
 petgraph = "0.6.5"
 rayon = "1.10"
 regex = "1.10.4"

--- a/moss/Cargo.toml
+++ b/moss/Cargo.toml
@@ -22,7 +22,6 @@ hex.workspace = true
 libsqlite3-sys.workspace = true
 log.workspace = true
 nix.workspace = true
-once_cell.workspace = true
 rayon.workspace = true
 reqwest.workspace = true
 serde.workspace = true


### PR DESCRIPTION
once_cell functionality was integrated into the stdlib in Rust 1.70.0. Switch to it so we can drop once_cell as a dependency.

While OnceLock is functionally similar to the thread-safe modules in once_cell the APIs are somewhat different. In this case the biggest difference is that you can't declare the function that creates the object when you declare the object itself, any caller that wants to use the object needs to provide the function to create it if it does not already exist. This is trivially worked around by wrapping the object in a function, which is what I did here.