### PR TITLE
boulder: Add RUSTFLAGS, enable frame pointers by default

### DIFF
--- a/boulder/data/macros/arch/base.yml
+++ b/boulder/data/macros/arch/base.yml
@@ -66,6 +66,7 @@ actions              :
             LDFLAGS="%(ldflags)"; export LDFLAGS
             CGO_LDFLAGS="%(ldflags) -Wl,--no-gc-sections"; export CGO_LDFLAGS
             DFLAGS="%(dflags)"; export DFLAGS
+            RUSTFLAGS="%(rustflags)"; export RUSTFLAGS
             CC="%(cc)"; export CC
             CXX="%(cxx)"; export CXX
             OBJC="%(objc)"; export OBJC
@@ -289,16 +290,19 @@ flags               :
         cxx       : "-pipe -Wformat -Wformat-security -Wno-error -fPIC"
         ld        : "-Wl,-O2,--gc-sections"
         d         : "-release -Hkeep-all-bodies -relocation-model=pic -wi"
+        rust      : ""
 
     - omit-frame-pointer:
         c         : "-fomit-frame-pointer -momit-leaf-frame-pointer"
         cxx       : "-fomit-frame-pointer -momit-leaf-frame-pointer"
         d         : "-frame-pointer=none"
+        rust      : ""
 
     - no-omit-frame-pointer:
         c         : "-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"
         cxx       : "-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"
         d         : "-frame-pointer=all"
+        rust      : "-Cforce-frame-pointers"
 
     # Toggle bindnow (ON)
     - bindnow:

--- a/boulder/src/build/job/phase.rs
+++ b/boulder/src/build/job/phase.rs
@@ -344,11 +344,17 @@ fn add_tuning(
             .iter()
             .filter_map(|flag| flag.get(tuning::CompilerFlag::D, toolchain)),
     );
+    let rustflags = fmt_flags(
+        flags
+            .iter()
+            .filter_map(|flag| flag.get(tuning::CompilerFlag::Rust, toolchain)),
+    );
 
     parser.add_definition("cflags", cflags);
     parser.add_definition("cxxflags", cxxflags);
     parser.add_definition("ldflags", ldflags);
     parser.add_definition("dflags", dflags);
+    parser.add_definition("rustflags", rustflags);
 
     Ok(())
 }

--- a/crates/stone_recipe/src/tuning.rs
+++ b/crates/stone_recipe/src/tuning.rs
@@ -85,6 +85,7 @@ pub enum CompilerFlag {
     C,
     Cxx,
     D,
+    Rust,
     Ld,
 }
 
@@ -93,6 +94,7 @@ pub struct CompilerFlags {
     c: Option<String>,
     cxx: Option<String>,
     d: Option<String>,
+    rust: Option<String>,
     ld: Option<String>,
 }
 
@@ -102,6 +104,7 @@ impl CompilerFlags {
             CompilerFlag::C => self.c.as_deref(),
             CompilerFlag::Cxx => self.cxx.as_deref(),
             CompilerFlag::D => self.d.as_deref(),
+            CompilerFlag::Rust => self.rust.as_deref(),
             CompilerFlag::Ld => self.ld.as_deref(),
         }
     }

--- a/test/base.yml
+++ b/test/base.yml
@@ -64,6 +64,7 @@ actions              :
             CGO_CXXFLAGS="%(cxxflags)"; export CGO_CXXFLAGS
             LDFLAGS="%(ldflags)"; export LDFLAGS
             CGO_LDFLAGS="%(ldflags) -Wl,--no-gc-sections"; export CGO_LDFLAGS
+            RUSTFLAGS="%(rustflags)"; export RUSTFLAGS
             CC="%(cc)"; export CC
             CXX="%(cxx)"; export CXX
             OBJC="%(objc)"; export OBJC


### PR DESCRIPTION
From the Rust docs:

> A space-separated list of custom flags to pass to all compiler invocations that Cargo performs. In contrast with `cargo rustc`, this is useful for passing a flag to _all_ compiler instances. (...) This string is split by whitespace

And define the default for that flag to be `-Cforce-frame-pointers`, which from the Rust docs force enables frame pointers. Note that setting this flag to `=false` or leaving it off does not necessarily mean that frame pointers will be removed as they can still be enabled by other means.

Though it is unlikely to be needed setting `frame-pointer: false` in the tuning section of a recipe will remove this flag.