### PR TITLE
Print help when argument required but not provided

### DIFF
--- a/boulder/src/cli/profile.rs
+++ b/boulder/src/cli/profile.rs
@@ -23,7 +23,7 @@ pub struct Command {
 pub enum Subcommand {
     #[command(about = "List profiles")]
     List,
-    #[command(about = "Add a new profile")]
+    #[command(about = "Add a new profile", arg_required_else_help(true))]
     Add {
         #[arg(help = "profile name")]
         name: String,

--- a/boulder/src/cli/recipe.rs
+++ b/boulder/src/cli/recipe.rs
@@ -51,7 +51,10 @@ pub enum Subcommand {
         )]
         release: Option<u64>,
     },
-    #[command(about = "Create skeletal stone.yaml recipe from source archive URIs", arg_required_else_help(true))]
+    #[command(
+        about = "Create skeletal stone.yaml recipe from source archive URIs",
+        arg_required_else_help(true)
+    )]
     New {
         #[arg(
             short,

--- a/boulder/src/cli/recipe.rs
+++ b/boulder/src/cli/recipe.rs
@@ -51,7 +51,7 @@ pub enum Subcommand {
         )]
         release: Option<u64>,
     },
-    #[command(about = "Create skeletal stone.yaml recipe from source archive URIs")]
+    #[command(about = "Create skeletal stone.yaml recipe from source archive URIs", arg_required_else_help(true))]
     New {
         #[arg(
             short,
@@ -63,7 +63,7 @@ pub enum Subcommand {
         #[arg(required = true, value_name = "URI", help = "Source archive URIs")]
         upstreams: Vec<Url>,
     },
-    #[command(about = "Update a recipe file")]
+    #[command(about = "Update a recipe file", arg_required_else_help(true))]
     Update {
         #[arg(short, long, required = true, help = "Update version")]
         version: String,

--- a/moss/src/cli/extract.rs
+++ b/moss/src/cli/extract.rs
@@ -20,6 +20,7 @@ pub fn command() -> Command {
     Command::new("extract")
         .about("Extract a `.stone` content to disk")
         .long_about("For all valid content-bearing archives, extract to disk")
+        .arg_required_else_help(true)
         .arg(arg!(<PATH> ... "files to inspect").value_parser(clap::value_parser!(PathBuf)))
 }
 

--- a/moss/src/cli/index.rs
+++ b/moss/src/cli/index.rs
@@ -22,6 +22,7 @@ pub fn command() -> Command {
     Command::new("index")
         .visible_alias("ix")
         .about("Index a collection of packages")
+        .arg_required_else_help(true)
         .arg(arg!(<INDEX_DIR> "directory of index files").value_parser(value_parser!(PathBuf)))
 }
 

--- a/moss/src/cli/info.rs
+++ b/moss/src/cli/info.rs
@@ -21,8 +21,9 @@ pub fn command() -> Command {
     Command::new("info")
         .about("Query packages")
         .long_about("List detailed package information from all available sources")
+        .arg_required_else_help(true)
         .arg(arg!(<NAME> ... "Packages to query").value_parser(clap::value_parser!(String)))
-        .arg(arg!(-f --files ... "Show files provided by package").action(clap::ArgAction::SetTrue))
+        .arg(arg!(-f --files ... "Show files provided by package").action(clap::ArgAction::SetTrue)) 
 }
 
 /// For all arguments, try to match a package

--- a/moss/src/cli/info.rs
+++ b/moss/src/cli/info.rs
@@ -23,7 +23,7 @@ pub fn command() -> Command {
         .long_about("List detailed package information from all available sources")
         .arg_required_else_help(true)
         .arg(arg!(<NAME> ... "Packages to query").value_parser(clap::value_parser!(String)))
-        .arg(arg!(-f --files ... "Show files provided by package").action(clap::ArgAction::SetTrue)) 
+        .arg(arg!(-f --files ... "Show files provided by package").action(clap::ArgAction::SetTrue))
 }
 
 /// For all arguments, try to match a package

--- a/moss/src/cli/inspect.rs
+++ b/moss/src/cli/inspect.rs
@@ -16,6 +16,7 @@ pub fn command() -> Command {
     Command::new("inspect")
         .about("Examine raw stone files")
         .long_about("Show detailed (debug) information on a local `.stone` file")
+        .arg_required_else_help(true)
         .arg(arg!(<PATH> ... "files to inspect").value_parser(clap::value_parser!(PathBuf)))
 }
 

--- a/moss/src/cli/install.rs
+++ b/moss/src/cli/install.rs
@@ -14,6 +14,7 @@ pub fn command() -> Command {
         .visible_alias("it")
         .about("Install packages")
         .long_about("Install the requested software to the local system")
+        .arg_required_else_help(true)
         .arg(arg!(<NAME> ... "packages to install").value_parser(value_parser!(String)))
         .arg(
             arg!(--to <blit_target> "Blit this install to the provided directory instead of the root")

--- a/moss/src/cli/list.rs
+++ b/moss/src/cli/list.rs
@@ -18,6 +18,7 @@ pub fn command() -> Command {
     Command::new("list")
         .about("List packages")
         .long_about("List packages according to a filter")
+        .arg_required_else_help(true)
         .subcommand_required(true)
         .subcommand(
             Command::new("installed")

--- a/moss/src/cli/remove.rs
+++ b/moss/src/cli/remove.rs
@@ -26,6 +26,7 @@ pub fn command() -> Command {
         .visible_alias("rm")
         .about("Remove packages")
         .long_about("Remove packages by name")
+        .arg_required_else_help(true)
         .arg(arg!(<NAME> ... "packages to install").value_parser(clap::value_parser!(String)))
 }
 

--- a/moss/src/cli/repo.rs
+++ b/moss/src/cli/repo.rs
@@ -30,6 +30,7 @@ pub fn command() -> Command {
     Command::new("repo")
         .about("Manage software repositories")
         .long_about("Manage the available software repositories visible to the installed system")
+        .arg_required_else_help(true)
         .subcommand_required(true)
         .subcommand(
             Command::new("add")

--- a/moss/src/cli/search.rs
+++ b/moss/src/cli/search.rs
@@ -20,6 +20,7 @@ pub fn command() -> Command {
         .visible_alias("sr")
         .about("Search packages")
         .long_about("Search packages by looking into package names and summaries.")
+        .arg_required_else_help(true)
         .arg(
             Arg::new(ARG_KEYWORD)
                 .required(true)

--- a/moss/src/cli/state.rs
+++ b/moss/src/cli/state.rs
@@ -14,6 +14,7 @@ pub fn command() -> Command {
     Command::new("state")
         .about("Manage state")
         .long_about("Manage state ...")
+        .arg_required_else_help(true)
         .subcommand_required(true)
         .subcommand(Command::new("active").about("List the active state"))
         .subcommand(Command::new("list").about("List all states"))

--- a/moss/src/cli/sync.rs
+++ b/moss/src/cli/sync.rs
@@ -26,6 +26,7 @@ pub fn command() -> Command {
         .visible_alias("up")
         .about("Sync packages")
         .long_about("Sync package selections with candidates from the highest priority repository")
+        .arg_required_else_help(true)
         .arg(arg!(-u --"update" "Update repositories before syncing"))
         .arg(arg!(--"upgrade-only" "Only sync packages that have a version upgrade"))
         .arg(


### PR DESCRIPTION
PR related to #168  discussion.
When additional argument needed, print short help instead of default clap error.
Align for both moss and boulder.

#Before
$boulder profile add
```
error: the following required arguments were not provided:
  --repo <REPOS>
  <NAME>

Usage: boulder profile add --repo <REPOS> <NAME>

For more information, try '--help'
```

#After
$boulder profile add
```
Add a new profile

Usage: boulder profile add [OPTIONS] --repo <REPOS> <NAME>

Arguments:
  <NAME>  profile name

Options:
      --cache-dir <CACHE_DIR>    
  -r, --repo <REPOS>             repository to add to profile, can be passed multiple times
      --config-dir <CONFIG_DIR>  
      --data-dir <DATA_DIR>      
      --moss-root <MOSS_ROOT>    
  -h, --help                     Print help (see more with '--help')
```