### PR TITLE
moss: Fix duplicate inserts

### DIFF
--- a/moss/src/db/meta/mod.rs
+++ b/moss/src/db/meta/mod.rs
@@ -315,16 +315,16 @@ impl Database {
                 batch_remove_impl(&ids, conn)?;
 
                 diesel::insert_into(model::meta::table).values(entries).execute(conn)?;
-                diesel::insert_into(model::meta_licenses::table)
+                diesel::insert_or_ignore_into(model::meta_licenses::table)
                     .values(licenses)
                     .execute(conn)?;
-                diesel::insert_into(model::meta_dependencies::table)
+                diesel::insert_or_ignore_into(model::meta_dependencies::table)
                     .values(dependencies)
                     .execute(conn)?;
-                diesel::insert_into(model::meta_providers::table)
+                diesel::insert_or_ignore_into(model::meta_providers::table)
                     .values(providers)
                     .execute(conn)?;
-                diesel::insert_into(model::meta_conflicts::table)
+                diesel::insert_or_ignore_into(model::meta_conflicts::table)
                     .values(conflicts)
                     .execute(conn)?;
                 Ok(())


### PR DESCRIPTION
This fixes the following error:

```
Error: build: build recipe: root: moss client: repository manager: meta db: diesel: UNIQUE constraint failed: meta_licenses.package, meta_licenses.license
```

It appears that the section that generates metadata for inserting into the database is generating multiple entries with the same id and value (these tables all have primary keys on the id and values). Perhaps the better solution is to de-duplicate the array before inserting it or figure out why it's creating duplicate items in the first place, but this gets things building on my machine at least.