### PR TITLE
boulder: Add support for sccache

### DIFF
--- a/boulder/data/macros/arch/base.yaml
+++ b/boulder/data/macros/arch/base.yaml
@@ -47,6 +47,7 @@ definitions:
     - strip          : "%(compiler_strip)"
     - path           : "%(compiler_path)"
     - ccachedir      : "%(compiler_cache)"
+    - sccachedir     : "%(scompiler_cache)"
     - pkgconfigpath  : "%(libdir)/pkgconfig:/usr/share/pkgconfig"
 
 actions              :
@@ -85,6 +86,10 @@ actions              :
             PATH="%(path)"; export PATH
             CCACHE_DIR="%(ccachedir)"; export CCACHE_DIR;
             test -z "$CCACHE_DIR" && unset CCACHE_DIR;
+            RUSTC_WRAPPER="%(rustc_wrapper)"; export RUSTC_WRAPPER;
+            test -z "$RUSTC_WRAPPER" && unset RUSTC_WRAPPER;
+            SCCACHE_DIR="%(sccachedir)"; export SCCACHE_DIR;
+            test -z "$SCCACHE_DIR" && unset SCCACHE_DIR;
             LANG="en_US.UTF-8"; export LANG
             LC_ALL="en_US.UTF-8"; export LC_ALL
             test -d "%(workdir)" || (echo "The work directory %(workdir) does not exist"; exit 1)

--- a/boulder/src/build/job/phase.rs
+++ b/boulder/src/build/job/phase.rs
@@ -149,6 +149,7 @@ impl Phase {
         parser.add_definition("workdir", work_dir.display());
 
         parser.add_definition("compiler_cache", "/mason/ccache");
+        parser.add_definition("scompiler_cache", "/mason/sccache");
 
         parser.add_definition("sourcedateepoch", recipe.build_time.timestamp());
 
@@ -157,6 +158,12 @@ impl Phase {
         } else {
             "/usr/bin:/bin"
         };
+
+        if ccache {
+            parser.add_definition("rustc_wrapper", "/usr/bin/sccache");
+        } else {
+            parser.add_definition("rustc_wrapper", "");
+        }
 
         /* Set the relevant compilers */
         if matches!(recipe.parsed.options.toolchain, Toolchain::Llvm) {

--- a/boulder/src/build/root.rs
+++ b/boulder/src/build/root.rs
@@ -104,7 +104,7 @@ fn packages(builder: &Builder) -> Vec<&str> {
     }
 
     if builder.ccache {
-        packages.push(CCACHE_PACKAGE);
+        packages.extend(CCACHE_PACKAGES);
     }
 
     packages.extend(builder.recipe.parsed.build.build_deps.iter().map(String::as_str));
@@ -184,7 +184,7 @@ const GNU32_PACKAGES: &[&str] = &["gcc-32bit-devel"];
 const LLVM_PACKAGES: &[&str] = &["clang"];
 const LLVM32_PACKAGES: &[&str] = &["clang-32bit", "libcxx-32bit-devel"];
 
-const CCACHE_PACKAGE: &str = "binary(ccache)";
+const CCACHE_PACKAGES: &[&str] = &["binary(ccache)", "binary(sccache)"];
 
 #[derive(Debug, Error)]
 pub enum Error {

--- a/boulder/src/container.rs
+++ b/boulder/src/container.rs
@@ -22,6 +22,7 @@ where
     let artefacts = paths.artefacts();
     let build = paths.build();
     let compiler = paths.ccache();
+    let rustc_wrapper = paths.sccache();
     let recipe = paths.recipe();
 
     Container::new(rootfs)
@@ -32,6 +33,7 @@ where
         .bind_rw(&artefacts.host, &artefacts.guest)
         .bind_rw(&build.host, &build.guest)
         .bind_rw(&compiler.host, &compiler.guest)
+        .bind_rw(&rustc_wrapper.host, &rustc_wrapper.guest)
         .bind_ro(&recipe.host, &recipe.guest)
         .run::<E>(f)?;
 

--- a/boulder/src/paths.rs
+++ b/boulder/src/paths.rs
@@ -50,6 +50,7 @@ impl Paths {
         util::ensure_dir_exists(&job.artefacts().host)?;
         util::ensure_dir_exists(&job.build().host)?;
         util::ensure_dir_exists(&job.ccache().host)?;
+        util::ensure_dir_exists(&job.sccache().host)?;
         util::ensure_dir_exists(&job.upstreams().host)?;
 
         Ok(job)
@@ -80,6 +81,13 @@ impl Paths {
         Mapping {
             host: self.host_root.join("ccache"),
             guest: self.guest_root.join("ccache"),
+        }
+    }
+
+    pub fn sccache(&self) -> Mapping {
+        Mapping {
+            host: self.host_root.join("sccache"),
+            guest: self.guest_root.join("sccache"),
         }
     }
 


### PR DESCRIPTION
Similarly to ccache, sccache can be used to cache rust compiler artefacts. Support is enabled via the same --compiler-cache flag.

Resolves #290.

**Testing**

`starship`:
sccache enabled (1st run)   : 4m27.21s  
sccache enabled (2nd run) : 2m38.11s
sccache disabled                  : 3m14.12s

`~/.cache/boulder/sccache/` is populated after building `starship`