### PR TITLE
boulder: Update GNU toolchain packages

### DIFF
--- a/boulder/src/build/root.rs
+++ b/boulder/src/build/root.rs
@@ -178,8 +178,8 @@ const BASE_PACKAGES: &[&str] = &[
 ];
 const BASE32_PACKAGES: &[&str] = &["glibc-32bit-devel"];
 
-const GNU_PACKAGES: &[&str] = &["binutils", "gcc-devel"];
-const GNU32_PACKAGES: &[&str] = &["gcc-32bit-devel"];
+const GNU_PACKAGES: &[&str] = &["binutils", "gcc", "g++"];
+const GNU32_PACKAGES: &[&str] = &["gcc-32bit", "g++-32bit"];
 
 const LLVM_PACKAGES: &[&str] = &["clang"];
 const LLVM32_PACKAGES: &[&str] = &["clang-32bit", "libcxx-32bit-devel"];


### PR DESCRIPTION
Updates the GNU toolchain packages after serpent-os/recipes#207