### PR TITLE
Update Display string for ContainerError::PivotRoot

### DIFF
--- a/crates/container/src/lib.rs
+++ b/crates/container/src/lib.rs
@@ -446,7 +446,7 @@ enum ContainerError {
     CloseReadFd(#[source] nix::Error),
     #[error("sethostname")]
     SetHostname(#[source] nix::Error),
-    #[error("pivotroot")]
+    #[error("pivot_root")]
     PivotRoot(#[source] nix::Error),
     #[error("unmount old root")]
     UnmountOldRoot(#[source] nix::Error),


### PR DESCRIPTION
This was meant to mirror the name of the function being called, I just noticed it didn't because of the missing underscore.