### PR TITLE
boulder: Hook up python providers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,6 +233,7 @@ dependencies = [
  "glob",
  "hex",
  "itertools 0.13.0",
+ "mailparse",
  "moss",
  "nix 0.27.1",
  "regex",
@@ -312,6 +313,16 @@ name = "cfg_aliases"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "charset"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f927b07c74ba84c7e5fe4db2baeb3e996ab2688992e39ac68ce3220a677c7e"
+dependencies = [
+ "base64",
+ "encoding_rs",
+]
 
 [[package]]
 name = "chrono"
@@ -626,6 +637,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "deranged"
@@ -1323,6 +1340,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "mailparse"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3da03d5980411a724e8aaf7b61a7b5e386ec55a7fb49ee3d0ff79efc7e5e7c7e"
+dependencies = [
+ "charset",
+ "data-encoding",
+ "quoted_printable",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1707,6 +1735,12 @@ checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "quoted_printable"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "640c9bd8497b02465aeef5375144c26062e0dcd5939dfcbb0f5db76cb8c17c73"
 
 [[package]]
 name = "rand"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ tokio-util = { version = "0.7.11", features = ["io"] }
 url = { version = "2.5.2", features = ["serde"] }
 xxhash-rust = { version = "0.8.11", features = ["xxh3"] }
 zstd = { version = "0.13.2", features = ["zstdmt"] }
+mailparse = "0.15.0"
 
 [profile.release]
 lto = "thin"

--- a/boulder/Cargo.toml
+++ b/boulder/Cargo.toml
@@ -43,3 +43,4 @@ strum.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 url.workspace = true
+mailparse.workspace = true

--- a/boulder/src/package/analysis.rs
+++ b/boulder/src/package/analysis.rs
@@ -37,6 +37,7 @@ impl<'a> Chain<'a> {
                 Box::new(handler::binary),
                 Box::new(handler::elf),
                 Box::new(handler::pkg_config),
+                Box::new(handler::python),
                 Box::new(handler::cmake),
                 // Catch-all if not excluded
                 Box::new(handler::include_any),

--- a/moss/src/dependency.rs
+++ b/moss/src/dependency.rs
@@ -47,7 +47,7 @@ pub enum Kind {
     /// CMake module dependency
     CMake,
 
-    /// Python dependency (unused)
+    /// Python dependency
     Python,
 
     /// Executable in /usr/bin


### PR DESCRIPTION
Uses mailparse to parse the RFC style package information from .dist-info or .egg-info directories and provides a python provider from the name.

Based off `pip3 show`