### PR TITLE
tui: Suspend indicatif & print normally

### DIFF
--- a/boulder/src/build/upstream.rs
+++ b/boulder/src/build/upstream.rs
@@ -84,7 +84,7 @@ pub fn sync(recipe: &Recipe, paths: &Paths) -> Result<(), Error> {
 
                 pb.finish();
                 mp.remove(&pb);
-                mp.println(format!("{} {}{}", "Shared".green(), upstream.name().bold(), cached_tag,))?;
+                mp.suspend(|| format!("{} {}{}", "Shared".green(), upstream.name().bold(), cached_tag,));
                 tp.inc(1);
 
                 Ok(()) as Result<_, Error>

--- a/boulder/src/draft/upstream.rs
+++ b/boulder/src/draft/upstream.rs
@@ -50,7 +50,7 @@ pub fn fetch_and_extract(upstreams: &[Url], extract_root: &Path) -> Result<Vec<U
 
                 fs::remove_file(archive_path).await?;
 
-                pb.println(format!("{} {}", "Fetched".green(), *uri));
+                pb.suspend(|| format!("{} {}", "Fetched".green(), *uri));
 
                 Ok(Upstream { uri: uri.clone(), hash })
             })

--- a/boulder/src/package/analysis.rs
+++ b/boulder/src/package/analysis.rs
@@ -92,17 +92,19 @@ impl<'a> Chain<'a> {
                 match response.decision {
                     Decision::NextHandler => continue 'handlers,
                     Decision::IgnoreFile { reason } => {
-                        pb.println(format!(
-                            "│A{} {} {}",
-                            "│ ×".yellow(),
-                            format!("{}", path.target_path.display()).dim(),
-                            format!("({reason})").yellow()
-                        ));
+                        pb.suspend(|| {
+                            println!(
+                                "│A{} {} {}",
+                                "│ ×".yellow(),
+                                format!("{}", path.target_path.display()).dim(),
+                                format!("({reason})").yellow()
+                            )
+                        });
                         pb.inc(1);
                         continue 'paths;
                     }
                     Decision::IncludeFile => {
-                        pb.println(format!("│A{} {}", "│ »".green(), path.target_path.display()));
+                        pb.suspend(|| println!("│A{} {}", "│ »".green(), path.target_path.display()));
                         pb.inc(1);
                         bucket.paths.push(path);
                         continue 'paths;

--- a/boulder/src/package/emit.rs
+++ b/boulder/src/package/emit.rs
@@ -218,7 +218,7 @@ fn emit_package(paths: &Paths, package: &Package) -> Result<(), Error> {
         out_file.flush()?;
     }
 
-    pb.println(format!("{} {filename}", "Emitted".green()));
+    pb.suspend(|| println!("{} {filename}", "Emitted".green()));
     pb.finish_and_clear();
 
     Ok(())

--- a/moss/src/cli/index.rs
+++ b/moss/src/cli/index.rs
@@ -142,7 +142,7 @@ fn get_meta(
 
     progress.finish();
     multi_progress.remove(&progress);
-    multi_progress.println(format!("{} {}", "Indexed".green(), relative_path.bold()))?;
+    multi_progress.suspend(|| println!("{} {}", "Indexed".green(), relative_path.bold()));
     total_progress.inc(1);
 
     Ok(meta)

--- a/moss/src/client/mod.rs
+++ b/moss/src/client/mod.rs
@@ -536,12 +536,8 @@ impl Client {
                     .unwrap_or_default();
 
                 // Write installed line
-                multi_progress.println(format!(
-                    "{} {}{}",
-                    "Installed".green(),
-                    package_name.clone().bold(),
-                    cached_tag,
-                ))?;
+                multi_progress
+                    .suspend(|| println!("{} {}{}", "Installed".green(), package_name.clone().bold(), cached_tag,));
 
                 // Inc total progress by 1
                 total_progress.inc(1);

--- a/moss/src/client/verify.rs
+++ b/moss/src/client/verify.rs
@@ -64,7 +64,7 @@ pub fn verify(client: &Client, yes: bool, verbose: bool) -> Result<(), client::E
         if !path.exists() {
             pb.inc(1);
             if verbose {
-                pb.println(format!(" {} {display_hash} - {files:?}", "×".yellow()));
+                pb.suspend(|| println!(" {} {display_hash} - {files:?}", "×".yellow()));
             }
             issues.push(Issue::MissingAsset {
                 hash: display_hash,
@@ -88,7 +88,7 @@ pub fn verify(client: &Client, yes: bool, verbose: bool) -> Result<(), client::E
         if verified_hash != hash {
             pb.inc(1);
             if verbose {
-                pb.println(format!(" {} {display_hash} - {files:?}", "×".yellow()));
+                pb.suspend(|| println!(" {} {display_hash} - {files:?}", "×".yellow()));
             }
             issues.push(Issue::CorruptAsset {
                 hash: display_hash,
@@ -100,7 +100,7 @@ pub fn verify(client: &Client, yes: bool, verbose: bool) -> Result<(), client::E
 
         pb.inc(1);
         if verbose {
-            pb.println(format!(" {} {display_hash} - {files:?}", "»".green()));
+            pb.suspend(|| println!(" {} {display_hash} - {files:?}", "»".green()));
         }
     }
 
@@ -152,7 +152,7 @@ pub fn verify(client: &Client, yes: bool, verbose: bool) -> Result<(), client::E
         pb.inc(1);
         if verbose {
             let mark = if num_issues > 0 { "×".yellow() } else { "»".green() };
-            pb.println(format!(" {mark} state #{}", state.id));
+            pb.suspend(|| println!(" {mark} state #{}", state.id));
         }
     }
 

--- a/moss/src/repository/manager.rs
+++ b/moss/src/repository/manager.rs
@@ -154,7 +154,7 @@ impl Manager {
 
                 self.refresh(id).await?;
 
-                pb.println(format!("{} {}", "Refreshed".green(), *id));
+                pb.suspend(|| println!("{} {}", "Refreshed".green(), *id));
 
                 Ok(())
             })
@@ -207,7 +207,7 @@ impl Manager {
 
                 self.refresh(id).await?;
 
-                pb.println(format!("{} {}", "Refreshed".green(), *id));
+                pb.suspend(|| println!("{} {}", "Refreshed".green(), *id));
 
                 Ok(()) as Result<_, Error>
             })


### PR DESCRIPTION
Fixed #313 

```
moss on  fix/indicatif-output [$!?] is 📦 v0.1.0 via 🦀 v1.80.1
❯ cargo run -- -D .root it mesa -y &>moss.log

moss on  fix/indicatif-output [$!?] is 📦 v0.1.0 via 🦀 v1.80.1 took 4s
❯ cat moss.log
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.10s
     Running `target/debug/moss -D .root it mesa -y`
The following package(s) will be installed:

brotli             1.1.0-4   json-c              0.17-2   libgpg-error        1.46-1   libxml2           2.12.4-6   p11-kit-libs      0.25.3-2   util-linux        2.40.2-8
bzip2              1.0.8-2   kbd                2.6.4-6   libpciaccess        0.17-2   libxshmfence       1.3.2-1   perl              5.38.2-7   wayland           1.23.0-4
ca-certificates  20240708-2   kmod                  31-8   libseccomp         2.5.4-2   libxxf86vm         1.1.5-2   polly            18.1.8-12   xz                 5.4.6-9
cryptsetup         2.7.0-2   libaio           0.3.113-1   libtasn1          4.19.0-1   llvm-libs        18.1.8-12   rustls-ffi        0.13.0-5   zlib              1.3.1-10
curl              8.9.1-10   libcap-ng          0.8.3-2   libx11            1.8.10-6   lvm2             2.03.21-5   sudo               0.2.3-6   zstd               1.5.5-4
elfutils-libs      0.191-4   libdrm           2.4.122-4   libxau            1.0.11-2   lz4                1.9.4-1   system-accounts    0.1.0-6
expat              2.6.2-4   libedit     20221030-3.1-2   libxcb            1.17.0-4   mesa             24.0.2-13   systemd          252.23-38
gdbm                1.23-2   libffi             3.4.4-3   libxext            1.3.6-4   nghttp2           1.59.0-4   terminus-font     4.49.1-1
gzip                1.13-4   libgcrypt         1.10.2-2   libxfixes          6.0.1-6   openssl           3.1.6-16   tzdata             2023d-4

Installed brotli (cached)
Installed gdbm (cached)
Installed curl (cached)
Installed bzip2 (cached)
Installed cryptsetup (cached)
Installed elfutils-libs (cached)
Installed ca-certificates (cached)
Installed expat (cached)
Installed gzip (cached)
Installed libaio (cached)
Installed libdrm (cached)
Installed kmod (cached)
Installed kbd (cached)
Installed json-c (cached)
Installed libcap-ng (cached)
Installed libpciaccess (cached)
Installed libffi (cached)
Installed libgcrypt (cached)
Installed libedit (cached)
Installed libgpg-error (cached)
Installed libseccomp (cached)
Installed libxfixes (cached)
Installed libxshmfence (cached)
Installed libtasn1 (cached)
Installed libxext (cached)
Installed libx11 (cached)
Installed libxxf86vm (cached)
Installed libxau (cached)
Installed libxcb (cached)
Installed llvm-libs (cached)
Installed libxml2 (cached)
Installed p11-kit-libs (cached)
Installed lz4 (cached)
Installed mesa (cached)
Installed nghttp2 (cached)
Installed openssl (cached)
Installed sudo (cached)
Installed polly (cached)
Installed lvm2 (cached)
Installed rustls-ffi (cached)
Installed system-accounts (cached)
Installed perl (cached)
Installed terminus-font (cached)
Installed systemd (cached)
Installed wayland (cached)
Installed util-linux (cached)
Installed xz (cached)
Installed zlib (cached)
Installed tzdata (cached)
Installed zstd (cached)
Trigger exited with non-zero status code: /usr/bin/systemd-tmpfiles ["--create"]
   Stdout:
   Stderr: /usr/lib/tmpfiles.d/journal-nocow.conf:26: Failed to replace specifiers in '/var/log/journal/%m': No such file or directory
/usr/lib/tmpfiles.d/systemd.conf:23: Failed to replace specifiers in '/run/log/journal/%m': No such file or directory
/usr/lib/tmpfiles.d/systemd.conf:25: Failed to replace specifiers in '/run/log/journal/%m': No such file or directory
/usr/lib/tmpfiles.d/systemd.conf:26: Failed to replace specifiers in '/run/log/journal/%m/*.journal*': No such file or directory
/usr/lib/tmpfiles.d/systemd.conf:29: Failed to replace specifiers in '/var/log/journal/%m': No such file or directory
/usr/lib/tmpfiles.d/systemd.conf:30: Failed to replace specifiers in '/var/log/journal/%m/system.journal': No such file or directory
/usr/lib/tmpfiles.d/systemd.conf:32: Failed to replace specifiers in '/var/log/journal/%m': No such file or directory
/usr/lib/tmpfiles.d/systemd.conf:33: Failed to replace specifiers in '/var/log/journal/%m/system.journal': No such file or directory
fchownat() of /dev/snd/seq failed: Operation not permitted
fchownat() of /dev/snd/timer failed: Operation not permitted
fchownat() of /dev/loop-control failed: Operation not permitted
fchownat() of /dev/kvm failed: Operation not permitted
fchownat() of /dev/vhost-net failed: Operation not permitted
fchownat() of /dev/vhost-vsock failed: Operation not permitted
```