### PR TITLE
moss: Disable automatic referer header in reqwest::ClientBuilder

### DIFF
--- a/moss/src/request.rs
+++ b/moss/src/request.rs
@@ -22,6 +22,7 @@ static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
 fn get_client() -> &'static reqwest::Client {
     CLIENT.get_or_init(|| {
         reqwest::ClientBuilder::new()
+            .referer(false)
             .user_agent(concat!(env!("CARGO_PKG_NAME"), "/", env!("CARGO_PKG_VERSION")))
             .build()
             .expect("build reqwest client")


### PR DESCRIPTION
Fixes #332. Seems to not have negative consequences elsewhere.