### PR TITLE
moss: vfs: Cache expensive path calc / allocations

### DIFF
--- a/moss/src/cli/info.rs
+++ b/moss/src/cli/info.rs
@@ -110,7 +110,7 @@ fn print_files(vfs: vfs::Tree<client::PendingFile>) {
             }
 
             let path = file.path();
-            let meta = match file.layout.entry {
+            let meta = match &file.layout.entry {
                 layout::Entry::Regular(hash, _) => Some(format!(" ({hash:2x})")),
                 layout::Entry::Symlink(source, _) => Some(format!(" -> {source}")),
                 _ => None,

--- a/moss/src/client/mod.rs
+++ b/moss/src/client/mod.rs
@@ -648,15 +648,10 @@ impl Client {
         match element {
             Element::Directory(name, item, children) => {
                 // Construct within the parent
-                self.blit_element_item(parent, cache, &name, item)?;
+                self.blit_element_item(parent, cache, name, item)?;
 
                 // open the new dir
-                let newdir = fcntl::openat(
-                    parent,
-                    name.as_str(),
-                    OFlag::O_RDONLY | OFlag::O_DIRECTORY,
-                    Mode::empty(),
-                )?;
+                let newdir = fcntl::openat(parent, name, OFlag::O_RDONLY | OFlag::O_DIRECTORY, Mode::empty())?;
                 for child in children.into_iter() {
                     self.blit_element(newdir, cache, child, progress)?;
                 }
@@ -664,7 +659,7 @@ impl Client {
                 Ok(())
             }
             Element::Child(name, item) => {
-                self.blit_element_item(parent, cache, &name, item)?;
+                self.blit_element_item(parent, cache, name, item)?;
                 Ok(())
             }
         }
@@ -678,8 +673,8 @@ impl Client {
     /// * `cache`   - raw file descriptor for the system asset pool tree
     /// * `subpath` - the base name of the new inode
     /// * `item`    - New inode being recorded
-    fn blit_element_item(&self, parent: RawFd, cache: RawFd, subpath: &str, item: PendingFile) -> Result<(), Error> {
-        match item.layout.entry {
+    fn blit_element_item(&self, parent: RawFd, cache: RawFd, subpath: &str, item: &PendingFile) -> Result<(), Error> {
+        match &item.layout.entry {
             layout::Entry::Regular(id, _) => {
                 let hash = format!("{:02x}", id);
                 let directory = if hash.len() >= 10 {


### PR DESCRIPTION
Basically fix `path() path() path() path() path()` being called 100x times. Cache it on first invocation by wrapping `BlitFitle` and calling these expensive methods only once.

Wall time went from 14.4s -> 600ms xD