### PR TITLE
Use sqlite exlusive transactions & optimize batching

### DIFF
--- a/moss/src/client/prune.rs
+++ b/moss/src/client/prune.rs
@@ -22,7 +22,7 @@ use tui::{
     pretty::autoprint_columns,
 };
 
-use crate::{client::cache, db, environment, package, state, Installation, State};
+use crate::{client::cache, db, package, state, Installation, State};
 
 /// The prune strategy for removing old states
 #[derive(Debug, Clone, Copy)]
@@ -208,18 +208,12 @@ fn prune_databases(
     install_db: &db::meta::Database,
     layout_db: &db::layout::Database,
 ) -> Result<(), Error> {
-    for chunk in &states.iter().map(|state| &state.id).chunks(environment::DB_BATCH_SIZE) {
-        // Remove db states
-        state_db.batch_remove(chunk)?;
-    }
-    for chunk in &packages.iter().chunks(environment::DB_BATCH_SIZE) {
-        // Remove db metadata
-        install_db.batch_remove(chunk)?;
-    }
-    for chunk in &packages.iter().chunks(environment::DB_BATCH_SIZE) {
-        // Remove db layouts
-        layout_db.batch_remove(chunk)?;
-    }
+    // Remove db states
+    state_db.batch_remove(states.iter().map(|s| &s.id))?;
+    // Remove db metadata
+    install_db.batch_remove(packages)?;
+    // Remove db layouts
+    layout_db.batch_remove(packages)?;
 
     Ok(())
 }

--- a/moss/src/db/mod.rs
+++ b/moss/src/db/mod.rs
@@ -32,6 +32,14 @@ impl Connection {
         let mut _guard = self.0.lock().expect("mutex guard");
         f(&mut _guard)
     }
+
+    fn exclusive_tx<T, E>(&self, f: impl FnOnce(&mut SqliteConnection) -> Result<T, E>) -> Result<T, E>
+    where
+        E: From<diesel::result::Error>,
+    {
+        let mut _guard = self.0.lock().expect("mutex guard");
+        _guard.exclusive_transaction(|tx| f(tx))
+    }
 }
 
 impl fmt::Debug for Connection {

--- a/moss/src/environment.rs
+++ b/moss/src/environment.rs
@@ -11,5 +11,3 @@ pub const MAX_NETWORK_CONCURRENCY: usize = 8;
 pub const FILE_READ_BUFFER_SIZE: usize = 4 * 1024 * 1024;
 /// Threshold to begin chunking file during read, 16 KiB
 pub const FILE_READ_CHUNK_THRESHOLD: usize = 16 * 1024;
-/// DB batch size
-pub const DB_BATCH_SIZE: usize = 1000;


### PR DESCRIPTION
We should have been using transactions for all mutable queries. We can always use `exclusive` since we're behind mutex