### PR TITLE
boulder: cfg! compat_dlang_emul_both -> compat_dlang_emul_flush

### DIFF
--- a/boulder/Cargo.toml
+++ b/boulder/Cargo.toml
@@ -8,7 +8,7 @@ rust-version.workspace = true
 
 [features]
 # See https://github.com/serpent-os/moss/issues/231 for details
-default = ["compat_dlang_emul_both"]
+default = ["compat_dlang_emul_flush"]
 # In this mode we create duplicate provides for both `386` and `x86` while depending on `x86`
 compat_dlang_emul_both = []
 # In this mode we create duplicate provides for both `386` and `x86` while depending on `386`


### PR DESCRIPTION
emul32 libs will now depend on 386 variants of the provided emul32 libs instead of x86.

Part of #223.