### PR TITLE
boulder/data: Add python-packaging as a dep for setup.py

### DIFF
--- a/boulder/data/macros/actions/python.yaml
+++ b/boulder/data/macros/actions/python.yaml
@@ -14,6 +14,7 @@ actions:
             python3 setup.py install --root="%(installroot)"
         dependencies:
             - python
+            - python-packaging # auto deps handler
 
     - pyproject_build:
         description: Build a wheel for python PEP517 projects


### PR DESCRIPTION
The packaging module is used to determine python dependencies automatically.