### PR TITLE
Use fs-err crate for better filesystem-related error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,7 @@ dependencies = [
  "derive_more",
  "dirs",
  "elf",
+ "fs-err",
  "futures",
  "glob",
  "hex",
@@ -416,6 +417,7 @@ name = "config"
 version = "0.1.0"
 dependencies = [
  "dirs",
+ "fs-err",
  "serde",
  "serde_yaml",
  "thiserror",
@@ -444,6 +446,7 @@ checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
 name = "container"
 version = "0.1.0"
 dependencies = [
+ "fs-err",
  "nix 0.27.1",
  "strum",
  "thiserror",
@@ -855,6 +858,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs-err"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a41f105fe1d5b6b34b2055e3dc59bb79b46b48b2040b9e6c7b4b5de097aa41"
+dependencies = [
+ "autocfg",
+ "tokio",
 ]
 
 [[package]]
@@ -1434,6 +1447,7 @@ dependencies = [
  "diesel",
  "diesel_migrations",
  "fnmatch",
+ "fs-err",
  "futures",
  "hex",
  "itertools 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ dirs = "5.0.1"
 elf = "0.7.4"
 indicatif = "0.17.8"
 itertools = "0.13.0"
+fs-err = { version = "2.11.0", features = ["tokio"] }
 futures = "0.3.30"
 glob = "0.3.1"
 hex = "0.4.3"

--- a/boulder/Cargo.toml
+++ b/boulder/Cargo.toml
@@ -30,6 +30,7 @@ derive_more.workspace = true
 dirs.workspace = true
 elf.workspace = true
 glob.workspace = true
+fs-err.workspace = true
 futures.workspace = true
 hex.workspace = true
 itertools.workspace = true

--- a/boulder/src/build.rs
+++ b/boulder/src/build.rs
@@ -10,6 +10,7 @@ use std::{
     time::Duration,
 };
 
+use fs_err as fs;
 use itertools::Itertools;
 use moss::runtime;
 use nix::{
@@ -203,7 +204,7 @@ impl Builder {
                                 );
 
                                 // Write env to $HOME/.profile
-                                std::fs::write(build_dir.join(".profile"), format_profile(script))?;
+                                fs::write(build_dir.join(".profile"), format_profile(script))?;
 
                                 let mut command = process::Command::new("/bin/bash")
                                     .arg("--login")
@@ -226,7 +227,7 @@ impl Builder {
                             script::Command::Content(content) => {
                                 // TODO: Proper temp file
                                 let script_path = "/tmp/script";
-                                std::fs::write(script_path, content).unwrap();
+                                fs::write(script_path, content).unwrap();
 
                                 let result = logged(*phase, is_pgo, "/bin/sh", |command| {
                                     command

--- a/boulder/src/build/root.rs
+++ b/boulder/src/build/root.rs
@@ -3,12 +3,12 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use std::collections::BTreeSet;
-use std::{fs, io};
+use std::io;
 
-use thiserror::Error;
-
+use fs_err as fs;
 use moss::{repository, runtime, Installation};
 use stone_recipe::{tuning::Toolchain, Upstream};
+use thiserror::Error;
 
 use crate::build::Builder;
 use crate::{container, timing, util, Timing};

--- a/boulder/src/build/upstream.rs
+++ b/boulder/src/build/upstream.rs
@@ -3,12 +3,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use std::{
-    fs, io,
+    io,
     path::{Path, PathBuf},
     str::FromStr,
     time::Duration,
 };
 
+use fs_err as fs;
 use futures::{stream, StreamExt, TryStreamExt};
 use moss::runtime;
 use nix::unistd::{linkat, LinkatFlags};

--- a/boulder/src/cli/chroot.rs
+++ b/boulder/src/cli/chroot.rs
@@ -2,13 +2,14 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use std::{fs, io, path::PathBuf, process};
+use std::{io, path::PathBuf, process};
 
 use boulder::{
     architecture::{self, BuildTarget},
     build, container, macros, recipe, Env, Macros, Paths, Recipe,
 };
 use clap::Parser;
+use fs_err as fs;
 use thiserror::Error;
 
 #[derive(Debug, Parser)]

--- a/boulder/src/cli/recipe.rs
+++ b/boulder/src/cli/recipe.rs
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 use std::{
-    fs,
     io::{self, Read},
     path::PathBuf,
     time::Duration,
@@ -14,6 +13,7 @@ use boulder::{
     macros, recipe, Env, Macros,
 };
 use clap::Parser;
+use fs_err as fs;
 use futures::StreamExt;
 use itertools::Itertools;
 use moss::{request, runtime};

--- a/boulder/src/draft.rs
+++ b/boulder/src/draft.rs
@@ -3,8 +3,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use std::path::Path;
-use std::{fs, io, path::PathBuf};
+use std::{io, path::PathBuf};
 
+use fs_err as fs;
 use itertools::Itertools;
 use moss::Dependency;
 use thiserror::Error;
@@ -70,7 +71,7 @@ impl Drafter {
 # SPDX-FileCopyrightText: © 2020-2024 Serpent OS Developers
 #
 # SPDX-License-Identifier: MPL-2.0
-#                
+#
 name        : {}
 version     : {}
 release     : 1

--- a/boulder/src/draft/build/autotools.rs
+++ b/boulder/src/draft/build/autotools.rs
@@ -1,6 +1,6 @@
-use std::fs;
 use std::path::Path;
 
+use fs_err as fs;
 use moss::{dependency, Dependency};
 use regex::Regex;
 

--- a/boulder/src/draft/build/meson.rs
+++ b/boulder/src/draft/build/meson.rs
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: Copyright © 2020-2024 Serpent OS Developers
 //
 // SPDX-License-Identifier: MPL-2.0
-use std::{fs, path::Path};
+use std::path::Path;
 
+use fs_err as fs;
 use moss::{dependency, Dependency};
 use regex::Regex;
 

--- a/boulder/src/draft/upstream.rs
+++ b/boulder/src/draft/upstream.rs
@@ -1,14 +1,11 @@
 use std::{io, path::Path, process::ExitStatus, time::Duration};
 
+use fs_err::tokio::{self as fs, File};
 use futures::{stream, StreamExt, TryStreamExt};
 use moss::{environment, request, runtime};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
-use tokio::{
-    fs::{self, File},
-    io::AsyncWriteExt,
-    process::Command,
-};
+use tokio::{io::AsyncWriteExt, process::Command};
 use tui::{MultiProgress, ProgressBar, ProgressStyle, Styled};
 use url::Url;
 

--- a/boulder/src/macros.rs
+++ b/boulder/src/macros.rs
@@ -3,8 +3,9 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use std::collections::BTreeMap;
-use std::{fs, io, path::Path};
+use std::{io, path::Path};
 
+use fs_err as fs;
 use thiserror::Error;
 
 use crate::{util, Env};

--- a/boulder/src/package.rs
+++ b/boulder/src/package.rs
@@ -2,8 +2,9 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 use std::collections::{btree_map, BTreeMap};
-use std::{fs, io, num::NonZeroU64};
+use std::{io, num::NonZeroU64};
 
+use fs_err as fs;
 use itertools::Itertools;
 use thiserror::Error;
 

--- a/boulder/src/package/analysis/handler.rs
+++ b/boulder/src/package/analysis/handler.rs
@@ -3,6 +3,7 @@ use std::{
     process::{Command, Stdio},
 };
 
+use fs_err as fs;
 use moss::{dependency, Dependency, Provider};
 
 use crate::package::collect::PathInfo;
@@ -129,7 +130,7 @@ pub fn python(bucket: &mut BucketMut, info: &mut PathInfo) -> Result<Response, B
         return Ok(Decision::NextHandler.into());
     }
 
-    let data = std::fs::read(&info.path)?;
+    let data = fs::read(&info.path)?;
     let mail = parse_mail(&data)?;
     let python_name = mail
         .get_headers()

--- a/boulder/src/package/analysis/handler/elf.rs
+++ b/boulder/src/package/analysis/handler/elf.rs
@@ -1,6 +1,5 @@
 use std::{
     ffi::CStr,
-    fs::File,
     path::{Path, PathBuf},
     process::Command,
 };
@@ -12,6 +11,7 @@ use elf::{
     note::Note,
     to_str,
 };
+use fs_err::File;
 
 use moss::{dependency, Dependency, Provider};
 use stone_recipe::tuning::Toolchain;

--- a/boulder/src/package/collect.rs
+++ b/boulder/src/package/collect.rs
@@ -3,12 +3,13 @@
 // SPDX-License-Identifier: MPL-2.0
 use std::{
     ffi::OsStr,
-    fs::{self, Metadata},
+    fs::Metadata,
     io,
     os::unix::fs::{FileTypeExt, MetadataExt},
     path::{Path, PathBuf},
 };
 
+use fs_err as fs;
 use glob::Pattern;
 use nix::libc::{S_IFDIR, S_IRGRP, S_IROTH, S_IRWXU, S_IXGRP, S_IXOTH};
 use stone::payload::{layout, Layout};

--- a/boulder/src/package/emit.rs
+++ b/boulder/src/package/emit.rs
@@ -2,12 +2,12 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 use std::{
-    fs::{self, File},
     io::{self, Write},
     num::NonZeroU64,
     time::Duration,
 };
 
+use fs_err::{self as fs, File};
 use itertools::Itertools;
 use moss::{package::Meta, Dependency, Provider};
 use thiserror::Error;
@@ -191,7 +191,7 @@ fn emit_package(paths: &Paths, package: &Package) -> Result<(), Error> {
     if !sorted_files.is_empty() {
         // Temp file for building content payload
         let temp_content_path = format!("/tmp/{}.tmp", &filename);
-        let mut temp_content = File::options()
+        let mut temp_content = fs::OpenOptions::new()
             .read(true)
             .append(true)
             .create(true)

--- a/boulder/src/package/emit/manifest/binary.rs
+++ b/boulder/src/package/emit/manifest/binary.rs
@@ -2,8 +2,9 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use std::{collections::BTreeSet, fs::File, path::Path};
+use std::{collections::BTreeSet, path::Path};
 
+use fs_err::File;
 use moss::Dependency;
 use stone::{
     header::v1::FileType,

--- a/boulder/src/package/emit/manifest/json.rs
+++ b/boulder/src/package/emit/manifest/json.rs
@@ -4,11 +4,11 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet},
-    fs::File,
     io::Write,
     path::Path,
 };
 
+use fs_err::File;
 use itertools::Itertools;
 use serde::Serialize;
 

--- a/boulder/src/recipe.rs
+++ b/boulder/src/recipe.rs
@@ -3,12 +3,13 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use std::{
-    env, fs, io,
+    env, io,
     path::{Path, PathBuf},
     process::Command,
 };
 
 use chrono::{DateTime, Utc};
+use fs_err as fs;
 use thiserror::Error;
 
 use crate::architecture::{self, BuildTarget};

--- a/boulder/src/util.rs
+++ b/boulder/src/util.rs
@@ -3,13 +3,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use std::{
-    fs, io,
+    io,
     num::NonZeroUsize,
     os::unix::fs::symlink,
     path::{Path, PathBuf},
     thread,
 };
 
+use fs_err as fs;
 use nix::unistd::{linkat, LinkatFlags};
 use url::Url;
 

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 
 [dependencies]
 dirs.workspace = true
+fs-err.workspace = true
 serde.workspace = true
 serde_yaml.workspace = true
 thiserror.workspace = true

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -3,10 +3,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use std::{
-    fmt, fs, io,
+    fmt, io,
     path::{Path, PathBuf},
 };
 
+use fs_err as fs;
 use serde::{de::DeserializeOwned, Serialize};
 use thiserror::Error;
 

--- a/crates/container/Cargo.toml
+++ b/crates/container/Cargo.toml
@@ -7,6 +7,7 @@ rust-version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+fs-err.workspace = true
 nix.workspace = true
 strum.workspace = true
 thiserror.workspace = true

--- a/crates/container/src/idmap.rs
+++ b/crates/container/src/idmap.rs
@@ -2,8 +2,9 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use std::{fs, process::Command};
+use std::process::Command;
 
+use fs_err as fs;
 use nix::unistd::{getgid, getuid, Pid, User};
 use thiserror::Error;
 

--- a/crates/container/src/lib.rs
+++ b/crates/container/src/lib.rs
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 use std::env::set_current_dir;
-use std::fs::{self, copy, create_dir_all, remove_dir};
 use std::io;
 use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
@@ -10,6 +9,7 @@ use std::process::Command;
 use std::ptr::addr_of_mut;
 use std::sync::atomic::{AtomicI32, Ordering};
 
+use fs_err::{self as fs, copy, create_dir_all, remove_dir};
 use nix::libc::SIGCHLD;
 use nix::mount::{mount, umount2, MntFlags, MsFlags};
 use nix::sched::{clone, CloneFlags};

--- a/moss/Cargo.toml
+++ b/moss/Cargo.toml
@@ -23,6 +23,7 @@ diesel.workspace = true
 diesel_migrations.workspace = true
 itertools.workspace = true
 fnmatch = { path = "../crates/fnmatch" }
+fs-err.workspace = true
 futures.workspace = true
 hex.workspace = true
 libsqlite3-sys.workspace = true

--- a/moss/src/cli/extract.rs
+++ b/moss/src/cli/extract.rs
@@ -3,13 +3,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use std::{
-    fs::{create_dir_all, hard_link, remove_dir_all, remove_file, File},
+    fs,
     io::{copy, Read, Seek, SeekFrom},
     os::unix::fs::symlink,
     path::PathBuf,
 };
 
 use clap::{arg, ArgMatches, Command};
+use fs_err::{create_dir_all, hard_link, remove_dir_all, remove_file, File};
 use moss::package::{self, MissingMetaFieldError};
 use stone::{payload::layout, read::PayloadKind};
 use thiserror::{self, Error};
@@ -56,7 +57,7 @@ pub fn handle(args: &ArgMatches) -> Result<(), Error> {
         }
 
         if let Some(content) = content {
-            let content_file = File::options()
+            let content_file = fs::OpenOptions::new()
                 .read(true)
                 .write(true)
                 .create(true)

--- a/moss/src/cli/index.rs
+++ b/moss/src/cli/index.rs
@@ -3,12 +3,13 @@
 // SPDX-License-Identifier: MPL-2.0
 use std::{
     collections::{btree_map, BTreeMap},
-    fs, io,
+    io,
     path::{Path, PathBuf, StripPrefixError},
     time::Duration,
 };
 
 use clap::{arg, value_parser, ArgMatches, Command};
+use fs_err as fs;
 use moss::{
     client,
     package::{self, Meta, MissingMetaFieldError},

--- a/moss/src/cli/inspect.rs
+++ b/moss/src/cli/inspect.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use clap::{arg, ArgMatches, Command};
-use std::fs::File;
+use fs_err::File;
 use std::path::PathBuf;
 use stone::payload::layout;
 use stone::payload::meta;

--- a/moss/src/client/boot.rs
+++ b/moss/src/client/boot.rs
@@ -5,13 +5,14 @@
 //! Boot management integration in moss
 
 use std::{
-    fs, io,
+    io,
     path::{Path, PathBuf},
     str::FromStr,
 };
 
 use blsforme::os_release::{self, OsRelease};
 use fnmatch::Pattern;
+use fs_err as fs;
 use stone::payload::{layout, Layout};
 use thiserror::{self, Error};
 

--- a/moss/src/client/cache.rs
+++ b/moss/src/client/cache.rs
@@ -11,12 +11,10 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use fs_err::tokio::{self as fs, File};
 use futures::StreamExt;
 use thiserror::Error;
-use tokio::{
-    fs::{self, File},
-    io::AsyncWriteExt,
-};
+use tokio::io::AsyncWriteExt;
 use url::Url;
 
 use stone::{payload, read::PayloadKind};
@@ -75,7 +73,7 @@ pub async fn fetch(
         fs::create_dir_all(parent).await?;
     }
 
-    if fs::try_exists(&destination_path).await? {
+    if tokio::fs::try_exists(&destination_path).await? {
         return Ok(Download {
             id: meta.id().into(),
             path: destination_path,

--- a/moss/src/client/mod.rs
+++ b/moss/src/client/mod.rs
@@ -10,14 +10,13 @@
 
 use std::{
     borrow::Borrow,
-    fmt,
-    fs::{self, create_dir_all},
-    io,
+    fmt, io,
     os::{fd::RawFd, unix::fs::symlink},
     path::{Path, PathBuf},
     time::Duration,
 };
 
+use fs_err::{self as fs, create_dir_all};
 use futures::{stream, StreamExt, TryStreamExt};
 use nix::{
     errno::Errno,

--- a/moss/src/client/prune.rs
+++ b/moss/src/client/prune.rs
@@ -10,10 +10,11 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::{
-    fs, io,
+    io,
     path::{Path, PathBuf},
 };
 
+use fs_err as fs;
 use itertools::Itertools;
 use thiserror::Error;
 
@@ -284,7 +285,7 @@ fn enumerate_files(root: impl AsRef<Path>) -> Result<Vec<PathBuf>, io::Error> {
             return Ok(vec![]);
         }
 
-        let contents = fs::read_dir(dir)?;
+        let contents = fs::read_dir(dir.as_ref())?;
 
         for entry in contents {
             let entry = entry?;

--- a/moss/src/client/verify.rs
+++ b/moss/src/client/verify.rs
@@ -2,10 +2,11 @@
 //
 // SPDX-License-Identifier: MPL-2.0
 
-use std::{collections::BTreeSet, fmt, fs, io, path::PathBuf};
+use std::{collections::BTreeSet, fmt, io, path::PathBuf};
 
 use itertools::Itertools;
 
+use fs_err as fs;
 use stone::{payload::layout, write::digest};
 use tui::{
     dialoguer::{theme::ColorfulTheme, Confirm},

--- a/moss/src/installation.rs
+++ b/moss/src/installation.rs
@@ -4,11 +4,9 @@
 
 //! Encapsulation of a target installation filesystem
 
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
+use fs_err as fs;
 use log::{trace, warn};
 use nix::unistd::{access, AccessFlags, Uid};
 use thiserror::Error;

--- a/moss/src/installation/lockfile.rs
+++ b/moss/src/installation/lockfile.rs
@@ -4,13 +4,13 @@
 
 use std::{
     fmt,
-    fs::{self, File},
     io::{self},
     os::fd::AsRawFd,
     path::PathBuf,
     sync::Arc,
 };
 
+use fs_err::{self as fs, File};
 use nix::fcntl::{flock, FlockArg};
 use thiserror::Error;
 

--- a/moss/src/registry/plugin/cobble.rs
+++ b/moss/src/registry/plugin/cobble.rs
@@ -3,10 +3,10 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use std::collections::BTreeMap;
-use std::fs::File;
 use std::io;
 use std::path::PathBuf;
 
+use fs_err::File;
 use thiserror::Error;
 
 use stone::read::PayloadKind;

--- a/moss/src/repository/manager.rs
+++ b/moss/src/repository/manager.rs
@@ -3,11 +3,11 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use std::collections::BTreeMap;
-use std::fs::{self, File};
 use std::io;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
+use fs_err::{self as fs, File};
 use futures::{stream, StreamExt, TryStreamExt};
 use thiserror::Error;
 use xxhash_rust::xxh3::xxh3_64;

--- a/moss/src/repository/mod.rs
+++ b/moss/src/repository/mod.rs
@@ -3,16 +3,14 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use std::collections::BTreeMap;
-use std::path::Path;
+use std::path::PathBuf;
 
 use derive_more::{Display, From, Into};
+use fs_err::tokio::File;
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tokio::{
-    fs::File,
-    io::{self, AsyncWriteExt},
-};
+use tokio::io::{self, AsyncWriteExt};
 use url::Url;
 
 use config::Config;
@@ -125,7 +123,7 @@ impl Config for Map {
     }
 }
 
-async fn fetch_index(url: Url, out_path: impl AsRef<Path>) -> Result<(), FetchError> {
+async fn fetch_index(url: Url, out_path: impl Into<PathBuf>) -> Result<(), FetchError> {
     let mut stream = request::get(url).await?;
 
     let mut out = File::create(out_path).await?;

--- a/moss/src/request.rs
+++ b/moss/src/request.rs
@@ -5,12 +5,13 @@
 use std::{io, path::PathBuf, sync::OnceLock};
 
 use bytes::Bytes;
+use fs_err::tokio::File;
 use futures::{
     stream::{self, BoxStream},
     Stream, StreamExt,
 };
 use thiserror::Error;
-use tokio::{fs::File, io::AsyncReadExt};
+use tokio::io::AsyncReadExt;
 use tokio_util::io::ReaderStream;
 use url::Url;
 


### PR DESCRIPTION
For example before:
```text
Error: env: io: Permission denied (os error 13)
```
and after:
```text
Error: env: io: failed to create directory `/usr/share/boulder`: Permission denied (os error 13)
```