### PR TITLE
boulder: Set SCHED_BATCH for builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,6 +247,7 @@ dependencies = [
  "stone_recipe",
  "strum",
  "thiserror",
+ "thread-priority",
  "tokio",
  "tui",
  "url",
@@ -2274,22 +2275,36 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.61"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread-priority"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d3b04d33c9633b8662b167b847c7ab521f83d1ae20f2321b65b5b925e532e36"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ serde_yaml = "0.9.34"
 sha2 = "0.10.8"
 strum = { version = "0.26.3", features = ["derive"] }
 thiserror = "1.0.61"
+thread-priority = "1.1.0"
 tokio = { version = "1.38.0", features = ["full"] }
 tokio-stream = { version = "0.1.15", features = ["time"] }
 tokio-util = { version = "0.7.11", features = ["io"] }

--- a/boulder/Cargo.toml
+++ b/boulder/Cargo.toml
@@ -42,6 +42,7 @@ serde_yaml.workspace = true
 sha2.workspace = true
 strum.workspace = true
 thiserror.workspace = true
+thread-priority.workspace = true
 tokio.workspace = true
 url.workspace = true
 mailparse.workspace = true


### PR DESCRIPTION
By default set the priority to SCHED_BATCH to hint to the scheduler that boulder is not interactive and to optimize scheduling for throughput. This should help improve system responsiveness during high CPU builds.

In case the user doesn't want this for some reason also add a flag to disable this behavior.