### PR TITLE
boulder: set CPP env to clang-cpp for llvm toolchain

### DIFF
--- a/boulder/src/build/job/phase.rs
+++ b/boulder/src/build/job/phase.rs
@@ -173,7 +173,7 @@ impl Phase {
             parser.add_definition("compiler_cxx", "clang++");
             parser.add_definition("compiler_objc", "clang");
             parser.add_definition("compiler_objcxx", "clang++");
-            parser.add_definition("compiler_cpp", "clang -E -");
+            parser.add_definition("compiler_cpp", "clang-cpp");
             parser.add_definition("compiler_objcpp", "clang -E -");
             parser.add_definition("compiler_objcxxcpp", "clang++ -E");
             parser.add_definition("compiler_d", "ldc2");


### PR DESCRIPTION
Resolves https://github.com/serpent-os/recipes/issues/99